### PR TITLE
Search parameter charges

### DIFF
--- a/src/ch-search-params.spec.ts
+++ b/src/ch-search-params.spec.ts
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, it } from '@jest/globals';
 import { ChSearchParams } from './ch-search-params.js';
+import './spec/uri-charge-matchers.js';
 
 describe('ChSearchParams', () => {
   it('parsed from string', () => {
@@ -21,9 +22,7 @@ describe('ChSearchParams', () => {
     const params = new ChSearchParams(input);
     const urlParams = new URLSearchParams(input);
 
-    expect([...params]).toEqual([
-      ['key foo', 'value bar'],
-    ]);
+    expect([...params]).toEqual([['key foo', 'value bar']]);
     expect(String(params)).toBe(input);
     expect([...params]).toEqual([...urlParams]);
     expect(String(params)).toBe(String(urlParams));
@@ -33,9 +32,7 @@ describe('ChSearchParams', () => {
     const params = new ChSearchParams(input);
     const urlParams = new URLSearchParams(input);
 
-    expect([...params]).toEqual([
-      ['key+foo', 'value+bar'],
-    ]);
+    expect([...params]).toEqual([['key+foo', 'value+bar']]);
     expect(String(params)).toBe(input);
     expect([...params]).toEqual([...urlParams]);
     expect(String(params)).toBe(String(urlParams));
@@ -196,6 +193,33 @@ describe('ChSearchParams', () => {
 
         expect(result).toEqual(urlResult);
       });
+    });
+  });
+
+  describe('charge', () => {
+    it('obtains parameter charges', () => {
+      const params = new ChSearchParams('?foo=bar(test)&foo=1&baz=(21)(22)&test');
+
+      expect(params.chargeOf('foo')).toHaveURIChargeItems({ bar: 'test' }, 1);
+      expect(params.chargeOf('baz')).toHaveURIChargeItems(21, 22);
+      expect(params.chargeOf('test')).toHaveURIChargeItems({});
+
+      expect(params.charge).toHaveURIChargeItems({
+        foo: [{ bar: 'test' }, 1],
+        baz: [21, 22],
+        test: {},
+      });
+    });
+    it('is cached', () => {
+      const params = new ChSearchParams('?foo=bar(test)&foo=1&baz=(21)(22)&test');
+
+      expect(params.charge).toBe(params.charge);
+      expect(params.chargeOf('foo')).toBe(params.chargeOf('foo'));
+    });
+    it('is none for missing parameter', () => {
+      const params = new ChSearchParams('?foo=bar(test)&foo=1&baz=(21)(22)&test');
+
+      expect(params.chargeOf('missing')).toBe(params.chargeParser.chargeRx.none);
     });
   });
 });

--- a/src/ch-search-params.spec.ts
+++ b/src/ch-search-params.spec.ts
@@ -16,6 +16,30 @@ describe('ChSearchParams', () => {
     expect([...params]).toEqual([...urlParams]);
     expect(String(params)).toBe(String(urlParams));
   });
+  it('treats `+` as space', () => {
+    const input = 'key+foo=value+bar';
+    const params = new ChSearchParams(input);
+    const urlParams = new URLSearchParams(input);
+
+    expect([...params]).toEqual([
+      ['key foo', 'value bar'],
+    ]);
+    expect(String(params)).toBe(input);
+    expect([...params]).toEqual([...urlParams]);
+    expect(String(params)).toBe(String(urlParams));
+  });
+  it('handles percent-encoded symbols', () => {
+    const input = 'key%2Bfoo=value%2Bbar';
+    const params = new ChSearchParams(input);
+    const urlParams = new URLSearchParams(input);
+
+    expect([...params]).toEqual([
+      ['key+foo', 'value+bar'],
+    ]);
+    expect(String(params)).toBe(input);
+    expect([...params]).toEqual([...urlParams]);
+    expect(String(params)).toBe(String(urlParams));
+  });
   it('ignores leading `?`', () => {
     const input = '?a=1&b=2&a=3';
     const params = new ChSearchParams(input);

--- a/src/ch-search-params.ts
+++ b/src/ch-search-params.ts
@@ -1,4 +1,5 @@
 import { isIterable } from '@proc7ts/primitives';
+import { decodeSearchParam, encodeSearchParam } from './impl/search-param-codec.js';
 
 export class ChSearchParams implements Iterable<[string, string]> {
 
@@ -21,7 +22,11 @@ export class ChSearchParams implements Iterable<[string, string]> {
         return;
       }
 
-      entries = search.split('&').map(part => part.split('=', 2) as [string, string?]);
+      entries = search.split('&').map((part) => {
+        const [key, value] = part.split('=', 2);
+
+        return [decodeSearchParam(key), value ? decodeSearchParam(value) : '']
+    });
     } else if (isIterable(search)) {
       entries = search;
     } else {
@@ -29,7 +34,7 @@ export class ChSearchParams implements Iterable<[string, string]> {
     }
 
     for (const [name, val] of entries) {
-      const value = val != null ? String(val) : '';
+      const value = val ? String(val) : '';
 
       this.#list.push([name, value]);
 
@@ -92,7 +97,7 @@ export class ChSearchParams implements Iterable<[string, string]> {
       if (out) {
         out += '&';
       }
-      out += encodeURIComponent(key) + '=' + encodeURIComponent(value);
+      out += encodeSearchParam(key) + '=' + encodeSearchParam(value);
     }
 
     return out;

--- a/src/ch-search-params.ts
+++ b/src/ch-search-params.ts
@@ -1,29 +1,57 @@
 import { isIterable } from '@proc7ts/primitives';
+import { ChURIPrimitive } from './charge/ch-uri-value.js';
+import { createURIChargeParser } from './charge/parse-uri-charge.js';
+import { URIChargeParser } from './charge/uri-charge-parser.js';
+import { URICharge } from './charge/uri-charge.js';
 import { decodeSearchParam, encodeSearchParam } from './impl/search-param-codec.js';
 
-export class ChSearchParams implements Iterable<[string, string]> {
+export class ChSearchParams<out TValue = ChURIPrimitive, out TCharge = URICharge<TValue>>
+  implements Iterable<[string, string]> {
 
+  readonly #chargeParser: URIChargeParser<TValue, TCharge>;
   readonly #list: ChSearchParamValue[] = [];
-  readonly #map: Map<string, ChSearchParam>;
+  readonly #map: Map<string, ChSearchParam<TValue, TCharge>>;
+  #charge?: TCharge;
 
   constructor(
     search:
       | string
       | Iterable<readonly [string, (string | null)?]>
       | Readonly<Record<string, string | null | undefined>>,
+    ...chargeParser: ChURIPrimitive extends TValue
+      ? URICharge<TValue> extends TCharge
+        ? [URIChargeParser<TValue, TCharge>?]
+        : [URIChargeParser<TValue, TCharge>]
+      : [URIChargeParser<TValue, TCharge>]
+  );
+
+  constructor(
+    search:
+      | string
+      | Iterable<readonly [string, (string | null)?]>
+      | Readonly<Record<string, string | null | undefined>>,
+    chargeParser: URIChargeParser<TValue, TCharge> = createURIChargeParser() as URIChargeParser<
+      TValue,
+      TCharge
+    >,
   ) {
+    this.#chargeParser = chargeParser;
     this.#map =
       typeof search === 'string'
         ? this.#parse(search)
         : this.#provide(isIterable(search) ? search : Object.entries(search));
   }
 
-  #parse(search: string): Map<string, ChSearchParam> {
+  get chargeParser(): URIChargeParser<TValue, TCharge> {
+    return this.#chargeParser;
+  }
+
+  #parse(search: string): Map<string, ChSearchParam<TValue, TCharge>> {
     if (search.startsWith('?')) {
       search = search.slice(1);
     }
 
-    const entries = new Map<string, ChSearchParam$Parsed>();
+    const entries = new Map<string, ChSearchParam$Parsed<TValue, TCharge>>();
 
     if (!search) {
       return entries;
@@ -37,7 +65,7 @@ export class ChSearchParams implements Iterable<[string, string]> {
       if (prev) {
         this.#list.push(prev.add(rawValue));
       } else {
-        const param = new ChSearchParam$Parsed(key, rawKey, rawValue);
+        const param = new ChSearchParam$Parsed<TValue, TCharge>(key, rawKey, rawValue);
 
         entries.set(key, param);
         this.#list.push(new ChSearchParamValue(param, 0));
@@ -47,8 +75,10 @@ export class ChSearchParams implements Iterable<[string, string]> {
     return entries;
   }
 
-  #provide(search: Iterable<readonly [string, (string | null)?]>): Map<string, ChSearchParam> {
-    const entries = new Map<string, ChSearchParam$Provided>();
+  #provide(
+    search: Iterable<readonly [string, (string | null)?]>,
+  ): Map<string, ChSearchParam<TValue, TCharge>> {
+    const entries = new Map<string, ChSearchParam$Provided<TValue, TCharge>>();
 
     for (const [key, val] of search) {
       const value = val ? String(val) : '';
@@ -57,7 +87,7 @@ export class ChSearchParams implements Iterable<[string, string]> {
       if (prev) {
         this.#list.push(prev.add(value));
       } else {
-        const param = new ChSearchParam$Provided(key, value);
+        const param = new ChSearchParam$Provided<TValue, TCharge>(key, value);
 
         entries.set(key, param);
         this.#list.push(new ChSearchParamValue(param, 0));
@@ -65,6 +95,21 @@ export class ChSearchParams implements Iterable<[string, string]> {
     }
 
     return entries;
+  }
+
+  get charge(): TCharge {
+    return this.#charge !== undefined ? this.#charge : (this.#charge = this.#parseCharge());
+  }
+
+  #parseCharge(): TCharge {
+    const { chargeParser } = this;
+    const mapRx = chargeParser.chargeRx.rxMap();
+
+    for (const entry of this.#map.values()) {
+      mapRx.put(entry.key, entry.getCharge(chargeParser));
+    }
+
+    return mapRx.endMap();
   }
 
   has(name: string): boolean {
@@ -81,6 +126,12 @@ export class ChSearchParams implements Iterable<[string, string]> {
     const entry = this.#map.get(name);
 
     return entry ? entry.values.slice() : [];
+  }
+
+  chargeOf(name: string): TCharge {
+    const entry = this.#map.get(name);
+
+    return entry ? entry.getCharge(this.chargeParser) : this.chargeParser.chargeRx.none;
   }
 
   *keys(): IterableIterator<string> {
@@ -101,7 +152,9 @@ export class ChSearchParams implements Iterable<[string, string]> {
     }
   }
 
-  forEach(callback: (value: string, key: string, parent: ChSearchParams) => void): void {
+  forEach(
+    callback: (value: string, key: string, parent: ChSearchParams<TValue, TCharge>) => void,
+  ): void {
     this.#list.forEach(({ key, value }) => callback(value, key, this));
   }
 
@@ -117,10 +170,10 @@ export class ChSearchParams implements Iterable<[string, string]> {
 
 class ChSearchParamValue {
 
-  readonly #param: ChSearchParam;
+  readonly #param: ChSearchParam<unknown, unknown>;
   readonly #index: number;
 
-  constructor(param: ChSearchParam, index: number) {
+  constructor(param: ChSearchParam<unknown, unknown>, index: number) {
     this.#param = param;
     this.#index = index;
   }
@@ -139,14 +192,43 @@ class ChSearchParamValue {
 
 }
 
-interface ChSearchParam {
-  readonly key: string;
-  readonly rawKey: string;
-  readonly values: string[];
-  readonly rawValues: string[];
+abstract class ChSearchParam<out TValue, out TCharge> {
+
+  #charge?: TCharge;
+
+  abstract readonly key: string;
+  abstract readonly rawKey: string;
+  abstract readonly values: string[];
+  abstract readonly rawValues: string[];
+
+  getCharge(parser: URIChargeParser<TValue, TCharge>): TCharge {
+    return this.#charge !== undefined ? this.#charge : (this.#charge = this.#parseCharge(parser));
+  }
+
+  #parseCharge(parser: URIChargeParser<TValue, TCharge>): TCharge {
+    const { rawValues } = this;
+
+    return rawValues.length === 1
+      ? parser.parse(rawValues[0]).charge
+      : this.#parseList(parser, rawValues);
+  }
+
+  #parseList(parser: URIChargeParser<TValue, TCharge>, rawValues: string[]): TCharge {
+    const { chargeRx } = parser;
+    const listRx = chargeRx.rxList();
+
+    for (const rawValue of rawValues) {
+      const itemRx = chargeRx.rxValue(itemCharge => listRx.add(itemCharge));
+
+      parser.parse(rawValue, itemRx);
+    }
+
+    return listRx.endList();
+  }
+
 }
 
-class ChSearchParam$Parsed implements ChSearchParam {
+class ChSearchParam$Parsed<out TValue, out TCharge> extends ChSearchParam<TValue, TCharge> {
 
   readonly #key: string;
   readonly #rawKey: string;
@@ -154,6 +236,7 @@ class ChSearchParam$Parsed implements ChSearchParam {
   readonly #rawValues: string[];
 
   constructor(key: string, rawKey: string, rawValue: string) {
+    super();
     this.#key = key;
     this.#rawKey = rawKey;
     this.#rawValues = [rawValue];
@@ -185,7 +268,7 @@ class ChSearchParam$Parsed implements ChSearchParam {
 
 }
 
-class ChSearchParam$Provided implements ChSearchParam {
+class ChSearchParam$Provided<out TValue, out TCharge> extends ChSearchParam<TValue, TCharge> {
 
   readonly #key: string;
   readonly #values: string[];
@@ -194,6 +277,7 @@ class ChSearchParam$Provided implements ChSearchParam {
   #rawValues?: string[];
 
   constructor(key: string, value: string) {
+    super();
     this.#key = key;
     this.#values = [value];
   }

--- a/src/charge/uri-charge-parser.ts
+++ b/src/charge/uri-charge-parser.ts
@@ -8,22 +8,34 @@ import { URIChargeRx } from './uri-charge-rx.js';
 
 export class URIChargeParser<out TValue = ChURIPrimitive, out TCharge = unknown> {
 
-  readonly #to: URIChargeTarget<TValue, TCharge>;
+  readonly #rx: URIChargeRx<TValue, TCharge>;
+  readonly #extParser: URIChargeExtParser<TValue, TCharge>;
 
   constructor(options: URIChargeParser.Options<TValue, TCharge>) {
-    const { rx } = options;
-    const decoder = defaultChURIValueDecoder;
+    const { rx, ext } = options;
 
-    this.#to = {
-      rx: rx.rxValue(),
-      decoder,
-      ext: new URIChargeExtParser(rx, options?.ext),
-      decode: input => decoder.decodeValue(this.#to, input),
-    };
+    this.#rx = rx;
+    this.#extParser = new URIChargeExtParser(rx, ext);
   }
 
-  parse(input: string): URIChargeParser.Result<TCharge> {
-    return parseChURIValue(this.#to, input);
+  get chargeRx(): URIChargeRx<TValue, TCharge> {
+    return this.#rx;
+  }
+
+  parse(
+    input: string,
+    rx: URIChargeRx.ValueRx<TValue, TCharge> = this.chargeRx.rxValue(),
+  ): URIChargeParser.Result<TCharge> {
+    const decoder = defaultChURIValueDecoder;
+
+    const to: URIChargeTarget<TValue, TCharge> = {
+      rx,
+      decoder,
+      ext: this.#extParser,
+      decode: input => decoder.decodeValue(to, input),
+    };
+
+    return parseChURIValue(to, input);
   }
 
 }

--- a/src/charge/uri-charge.ts
+++ b/src/charge/uri-charge.ts
@@ -1,6 +1,6 @@
 import { ChURIDirective, ChURIEntity, ChURIPrimitive } from './ch-uri-value.js';
 
-export abstract class URICharge<out TValue = URIChargeItem> {
+export abstract class URICharge<out TValue = ChURIPrimitive> {
 
   static get none(): URICharge.None {
     return URICharge$None$instance;

--- a/src/impl/search-param-codec.ts
+++ b/src/impl/search-param-codec.ts
@@ -1,5 +1,5 @@
 export function decodeSearchParam(encoded: string): string {
-  return decodeURIComponent(encoded.replaceAll('+', ' '))
+  return decodeURIComponent(encoded.replaceAll('+', ' '));
 }
 
 export function encodeSearchParam(decoded: string): string {

--- a/src/impl/search-param-codec.ts
+++ b/src/impl/search-param-codec.ts
@@ -1,0 +1,7 @@
+export function decodeSearchParam(encoded: string): string {
+  return decodeURIComponent(encoded.replaceAll('+', ' '))
+}
+
+export function encodeSearchParam(decoded: string): string {
+  return encodeURIComponent(decoded).replace(/%20/g, '+');
+}


### PR DESCRIPTION
- Treat `+` as space within search parameters
- Preserve raw search parameter values
- Correct `URICharge` signature
- Parse search parameter charges
