### PR TITLE
Reactive charge receivers

### DIFF
--- a/src/ch-search-params.ts
+++ b/src/ch-search-params.ts
@@ -103,13 +103,14 @@ export class ChSearchParams<out TValue = ChURIPrimitive, out TCharge = URICharge
 
   #parseCharge(): TCharge {
     const { chargeParser } = this;
-    const mapRx = chargeParser.chargeRx.rxMap();
 
-    for (const entry of this.#map.values()) {
-      mapRx.put(entry.key, entry.getCharge(chargeParser));
-    }
+    return chargeParser.chargeRx.rxMap(rx => {
+      for (const entry of this.#map.values()) {
+        rx.put(entry.key, entry.getCharge(chargeParser));
+      }
 
-    return mapRx.endMap();
+      return rx.endMap();
+    });
   }
 
   has(name: string): boolean {

--- a/src/ch-search-params.ts
+++ b/src/ch-search-params.ts
@@ -259,13 +259,14 @@ class ChSearchParam$Parsed<out TValue, out TCharge> extends ChSearchParam<TValue
 
   #parseList(parser: URIChargeParser<TValue, TCharge>, rawValues: string[]): TCharge {
     const { chargeRx } = parser;
-    const listRx = chargeRx.rxList();
 
-    for (const rawValue of rawValues) {
-      listRx.add(chargeRx.rxValue(itemRx => parser.parse(rawValue, itemRx).charge));
-    }
+    return chargeRx.rxList(listRx => {
+      for (const rawValue of rawValues) {
+        listRx.add(chargeRx.rxValue(itemRx => parser.parse(rawValue, itemRx).charge));
+      }
 
-    return listRx.endList();
+      return listRx.endList();
+    });
   }
 
 }
@@ -318,13 +319,14 @@ class ChSearchParam$Provided<out TValue, out TCharge> extends ChSearchParam<TVal
 
   #parseList(parser: URIChargeParser<TValue, TCharge>, values: string[]): TCharge {
     const { chargeRx } = parser;
-    const listRx = chargeRx.rxList();
 
-    for (const value of values) {
-      listRx.addValue(value, 'string');
-    }
+    return chargeRx.rxList(listRx => {
+      for (const value of values) {
+        listRx.addValue(value, 'string');
+      }
 
-    return listRx.endList();
+      return listRx.endList();
+    });
   }
 
 }

--- a/src/ch-search-params.ts
+++ b/src/ch-search-params.ts
@@ -261,9 +261,7 @@ class ChSearchParam$Parsed<out TValue, out TCharge> extends ChSearchParam<TValue
     const listRx = chargeRx.rxList();
 
     for (const rawValue of rawValues) {
-      const itemRx = chargeRx.rxValue(itemCharge => listRx.add(itemCharge));
-
-      parser.parse(rawValue, itemRx);
+      listRx.add(chargeRx.rxValue(itemRx => parser.parse(rawValue, itemRx).charge));
     }
 
     return listRx.endList();

--- a/src/charge/ch-uri-value-builder.ts
+++ b/src/charge/ch-uri-value-builder.ts
@@ -161,8 +161,8 @@ class ChURIValueBuilder$MapRx<out TValue, out TRx extends ChURIValueBuilder<TVal
   override rxMap(
     key: string,
     parse: (rx: ChURIValueBuilder.MapRx<TValue>) => ChURIValue<TValue>,
-  ): ChURIValue<TValue> {
-    return this.chargeRx.rxMap(parse, this.#addMap(key));
+  ): void {
+    this.chargeRx.rxMap(parse, this.#addMap(key));
   }
 
   #addMap(key: string): ChURIMap<TValue> {
@@ -181,8 +181,8 @@ class ChURIValueBuilder$MapRx<out TValue, out TRx extends ChURIValueBuilder<TVal
   override rxList(
     key: string,
     parse: (rx: ChURIValueBuilder.ListRx<TValue>) => ChURIValue<TValue>,
-  ): ChURIValue<TValue> {
-    return this.chargeRx.rxList(parse, this.#addList(key));
+  ): void {
+    this.chargeRx.rxList(parse, this.#addList(key));
   }
 
   #addList(key: string): ChURIList<TValue> {

--- a/src/charge/ch-uri-value-builder.ts
+++ b/src/charge/ch-uri-value-builder.ts
@@ -44,8 +44,8 @@ export class ChURIValueBuilder<out TValue = ChURIPrimitive>
     return value;
   }
 
-  rxValue(endValue?: URIChargeRx.End<ChURIValue<TValue>>): ChURIValueBuilder.ValueRx<TValue> {
-    return new this.ns.ValueRx(this, endValue);
+  rxValue<T>(parse: (rx: URIChargeRx.ValueRx<TValue, ChURIValue<TValue>>) => T): T {
+    return parse(new this.ns.ValueRx(this));
   }
 
   rxMap(
@@ -90,7 +90,6 @@ export namespace ChURIValueBuilder {
       TRx extends ChURIValueBuilder<TValue> = ChURIValueBuilder<TValue>,
     >(
       chargeRx: TRx,
-      endValue?: URIChargeRx.End<ChURIValue<TValue>>,
     ) => ValueRx<TValue, TRx>;
   }
 

--- a/src/charge/ch-uri-value-builder.ts
+++ b/src/charge/ch-uri-value-builder.ts
@@ -44,15 +44,12 @@ export class ChURIValueBuilder<out TValue = ChURIPrimitive>
     return value;
   }
 
-  rxValue<T>(parse: (rx: URIChargeRx.ValueRx<TValue, ChURIValue<TValue>>) => T): T {
+  rxValue<T>(parse: (rx: ChURIValueBuilder.ValueRx<TValue>) => T): T {
     return parse(new this.ns.ValueRx(this));
   }
 
-  rxMap(
-    endMap?: URIChargeRx.End<ChURIMap<TValue>>,
-    map?: ChURIMap<TValue>,
-  ): ChURIValueBuilder.MapRx<TValue> {
-    return new this.ns.MapRx(this, endMap, map);
+  rxMap<T>(parse: (rx: ChURIValueBuilder.MapRx<TValue>) => T, map?: ChURIMap<TValue>): T {
+    return parse(new this.ns.MapRx(this, map));
   }
 
   rxList(
@@ -104,7 +101,6 @@ export namespace ChURIValueBuilder {
       TRx extends ChURIValueBuilder<TValue> = ChURIValueBuilder<TValue>,
     >(
       chargeRx: TRx,
-      endMap?: URIChargeRx.End<ChURIMap<TValue>>,
       list?: ChURIMap<TValue>,
     ) => MapRx<TValue, TRx>;
   }
@@ -151,22 +147,20 @@ class ChURIValueBuilder$MapRx<out TValue, out TRx extends ChURIValueBuilder<TVal
   readonly #map: ChURIMap<TValue>;
   readonly #endMap?: URIChargeRx.End<ChURIMap<TValue>>;
 
-  constructor(
-    chargeRx: TRx,
-    endMap?: URIChargeRx.End<ChURIMap<TValue>>,
-    map: ChURIMap<TValue> = {},
-  ) {
-    super(chargeRx, endMap);
+  constructor(chargeRx: TRx, map: ChURIMap<TValue> = {}) {
+    super(chargeRx);
     this.#map = map;
-    this.#endMap = endMap;
   }
 
   override put(key: string, charge: ChURIValue<TValue>): void {
     this.#map[key] = charge;
   }
 
-  startMap(key: string): ChURIValueBuilder.MapRx<TValue> {
-    return this.chargeRx.rxMap(undefined, this.#addMap(key));
+  rxMap(
+    key: string,
+    parse: (rx: ChURIValueBuilder.MapRx<TValue>) => ChURIValue<TValue>,
+  ): ChURIValue<TValue> {
+    return this.chargeRx.rxMap(parse, this.#addMap(key));
   }
 
   #addMap(key: string): ChURIMap<TValue> {

--- a/src/charge/ch-uri-value.ts
+++ b/src/charge/ch-uri-value.ts
@@ -1,4 +1,4 @@
-import { encodeURICharge } from './encode-uri-charge.js';
+import { encodeURICharge } from './uri-charge-codec.js';
 import { URIChargeEncodable } from './uri-charge-encodable.js';
 
 export type ChURIValue<TValue = ChURIPrimitive> =

--- a/src/charge/ext/number-values.ch-uri-ext.ts
+++ b/src/charge/ext/number-values.ch-uri-ext.ts
@@ -2,20 +2,20 @@ import { URIChargeExt } from '../uri-charge-ext.js';
 import { URIChargeRx } from '../uri-charge-rx.js';
 
 export function NumberValuesChURIExt<TValue, TCharge>(
-  _charge: URIChargeRx<TValue, TCharge>,
+  charge: URIChargeRx<TValue, TCharge>,
 ): URIChargeExt<TValue, TCharge> {
   return {
     entities: {
-      ['!Infinity'](rx: URIChargeRx.ValueRx<TValue, TCharge>): TCharge {
-        return rx.setValue(Infinity, 'number');
+      ['!Infinity'](): TCharge {
+        return charge.createValue(Infinity, 'number');
       },
 
-      ['!-Infinity'](rx: URIChargeRx.ValueRx<TValue, TCharge>): TCharge {
-        return rx.setValue(-Infinity, 'number');
+      ['!-Infinity'](): TCharge {
+        return charge.createValue(-Infinity, 'number');
       },
 
-      ['!NaN']<TCharge>(rx: URIChargeRx.ValueRx<TValue, TCharge>): TCharge {
-        return rx.setValue(NaN, 'number');
+      ['!NaN'](): TCharge {
+        return charge.createValue(NaN, 'number');
       },
     },
   };

--- a/src/charge/ext/number-values.ch-uri-ext.ts
+++ b/src/charge/ext/number-values.ch-uri-ext.ts
@@ -6,15 +6,15 @@ export function NumberValuesChURIExt<TValue, TCharge>(
 ): URIChargeExt<TValue, TCharge> {
   return {
     entities: {
-      ['!Infinity']({ rx }: URIChargeExt.Context<TValue, TCharge>): TCharge {
+      ['!Infinity'](rx: URIChargeRx.ValueRx<TValue, TCharge>): TCharge {
         return rx.setValue(Infinity, 'number');
       },
 
-      ['!-Infinity']({ rx }: URIChargeExt.Context<TValue, TCharge>): TCharge {
+      ['!-Infinity'](rx: URIChargeRx.ValueRx<TValue, TCharge>): TCharge {
         return rx.setValue(-Infinity, 'number');
       },
 
-      ['!NaN']<TCharge>({ rx }: URIChargeExt.Context<TValue, TCharge>): TCharge {
+      ['!NaN']<TCharge>(rx: URIChargeRx.ValueRx<TValue, TCharge>): TCharge {
         return rx.setValue(NaN, 'number');
       },
     },

--- a/src/charge/impl/ch-uri-value-decoder.ts
+++ b/src/charge/impl/ch-uri-value-decoder.ts
@@ -2,7 +2,6 @@ import { URIChargeRx } from '../uri-charge-rx.js';
 import { URIChargeExtParser } from './uri-charge-ext-parser.js';
 
 export interface ChURIValueDecoder {
-  decodeKey(rawKey: string): string;
   decodeString(rawString: string): string;
   decodeValue<TValue, TCharge>(
     rx: URIChargeRx.ValueRx<TValue, TCharge>,
@@ -12,12 +11,11 @@ export interface ChURIValueDecoder {
 }
 
 export const defaultChURIValueDecoder: ChURIValueDecoder = {
-  decodeKey: decodeChURIKey,
   decodeString: decodeURIComponent,
   decodeValue: decodeChURIValue,
 };
 
-function decodeChURIKey(rawKey: string): string {
+export function decodeChURIKey(rawKey: string): string {
   return decodeURIComponent(rawKey.startsWith("'") ? rawKey.slice(1) : rawKey);
 }
 

--- a/src/charge/impl/ch-uri-value-decoder.ts
+++ b/src/charge/impl/ch-uri-value-decoder.ts
@@ -26,6 +26,14 @@ export function decodeChURIValue<TValue, TCharge>(
   return decodeStringChURIValue(rx, input);
 }
 
+export function decodeChURIDirectiveArg<TValue, TCharge>(
+  rx: URIChargeRx.ValueRx<TValue, TCharge>,
+  ext: URIChargeExtParser<TValue, TCharge>,
+  input: string,
+): TCharge {
+  return decodeChURIValue(rx, ext, input);
+}
+
 export type ChURIValuePrefix =
   | '!'
   | "'"

--- a/src/charge/impl/ch-uri-value-decoder.ts
+++ b/src/charge/impl/ch-uri-value-decoder.ts
@@ -1,34 +1,39 @@
-import { URIChargeRx } from '../uri-charge-rx.js';
-import { URIChargeTarget } from './uri-charge-target.js';
+import { AnyURIChargeRx, URIChargeTarget } from './uri-charge-target.js';
 
 export type ChURIValueDecoder = <TValue, TCharge>(
   to: URIChargeTarget<TValue, TCharge>,
+  rx: AnyURIChargeRx<TValue, TCharge>,
+  key: string,
   input: string,
 ) => TCharge;
 
 export function decodeChURIValue<TValue, TCharge>(
   to: URIChargeTarget<TValue, TCharge>,
+  rx: AnyURIChargeRx<TValue, TCharge>,
+  key: string,
   input: string,
 ): TCharge {
   if (!input) {
     // Empty string treated as is.
-    return to.setValue('', 'string');
+    return to.setValue(rx, key, '', 'string');
   }
 
   const decoder = CHURI_VALUE_DECODERS[input[0]];
 
   if (decoder) {
-    return decoder(to, input);
+    return decoder(to, rx, key, input);
   }
 
-  return decodeStringChURIValue(to, input);
+  return decodeStringChURIValue(to, rx, key, input);
 }
 
 export function decodeChURIDirectiveArg<TValue, TCharge>(
   to: URIChargeTarget<TValue, TCharge>,
+  rx: AnyURIChargeRx<TValue, TCharge>,
+  key: string,
   input: string,
 ): TCharge {
-  return decodeChURIValue(to, input);
+  return decodeChURIValue(to, rx, key, input);
 }
 
 export type ChURIValuePrefix =
@@ -47,10 +52,7 @@ export type ChURIValuePrefix =
   | '9';
 
 const CHURI_VALUE_DECODERS: {
-  readonly [prefix: string]: <TValue, TCharge>(
-    to: URIChargeTarget<TValue, TCharge>,
-    input: string,
-  ) => TCharge;
+  readonly [prefix: string]: ChURIValueDecoder;
 } = {
   '!': decodeExclamationPrefixedChURIValue,
   "'": decodeQuotedChURIValue,
@@ -69,64 +71,76 @@ const CHURI_VALUE_DECODERS: {
 
 function decodeExclamationPrefixedChURIValue<TValue, TCharge>(
   to: URIChargeTarget<TValue, TCharge>,
+  rx: AnyURIChargeRx<TValue, TCharge>,
+  key: string,
   input: string,
 ): TCharge {
   if (input.length === 1) {
-    return to.setValue(true, 'boolean');
+    return to.setValue(rx, key, true, 'boolean');
   }
   if (input === '!!') {
-    return to.rxList(rx => rx.endList());
+    return to.rxList(rx, key, listRx => listRx.endList());
   }
 
-  return to.setEntity(input);
+  return to.setEntity(rx, key, input);
 }
 
 function decodeMinusSignedChURIValue<TValue, TCharge>(
-  rx: URIChargeRx.ValueRx<TValue, TCharge>,
+  to: URIChargeTarget<TValue, TCharge>,
+  rx: AnyURIChargeRx<TValue, TCharge>,
+  key: string,
   input: string,
 ): TCharge {
   if (input.length === 1) {
-    return rx.setValue(false, 'boolean');
+    return to.setValue(rx, key, false, 'boolean');
   }
   if (input === '--') {
-    return rx.setValue(null, 'null');
+    return to.setValue(rx, key, null, 'null');
   }
 
   const secondChar = input[1];
 
   if (secondChar >= '0' && secondChar <= '9') {
-    return decodeNumericChURIValue(rx, input, 1, negate);
+    return decodeNumericChURIValue(to, rx, key, input, 1, negate);
   }
 
-  return decodeStringChURIValue(rx, input);
+  return decodeStringChURIValue(to, rx, key, input);
 }
 
 function decodeNumberChURIValue<TValue, TCharge>(
-  rx: URIChargeRx.ValueRx<TValue, TCharge>,
+  to: URIChargeTarget<TValue, TCharge>,
+  rx: AnyURIChargeRx<TValue, TCharge>,
+  key: string,
   input: string,
 ): TCharge {
-  return rx.setValue(Number(input), 'number');
+  return to.setValue(rx, key, Number(input), 'number');
 }
 
 function decodeQuotedChURIValue<TValue, TCharge>(
-  rx: URIChargeRx.ValueRx<TValue, TCharge>,
+  to: URIChargeTarget<TValue, TCharge>,
+  rx: AnyURIChargeRx<TValue, TCharge>,
+  key: string,
   input: string,
 ): TCharge {
-  return rx.setValue(decodeURIComponent(input.slice(1)), 'string');
+  return to.setValue(rx, key, decodeURIComponent(input.slice(1)), 'string');
 }
 
 function decodeStringChURIValue<TValue, TCharge>(
-  rx: URIChargeRx.ValueRx<TValue, TCharge>,
+  to: URIChargeTarget<TValue, TCharge>,
+  rx: AnyURIChargeRx<TValue, TCharge>,
+  key: string,
   input: string,
 ): TCharge {
-  return rx.setValue(decodeURIComponent(input), 'string');
+  return to.setValue(rx, key, decodeURIComponent(input), 'string');
 }
 
 function decodeUnsignedChURIValue<TValue, TCharge>(
-  rx: URIChargeRx.ValueRx<TValue, TCharge>,
+  to: URIChargeTarget<TValue, TCharge>,
+  rx: AnyURIChargeRx<TValue, TCharge>,
+  key: string,
   input: string,
 ): TCharge {
-  return decodeNumericChURIValue(rx, input, 0, asis);
+  return decodeNumericChURIValue(to, rx, key, input, 0, asis);
 }
 
 function negate<T extends number | bigint>(value: T): T {
@@ -138,17 +152,26 @@ function asis<T extends number | bigint>(value: T): T {
 }
 
 function decodeNumericChURIValue<TValue, TCharge>(
-  rx: URIChargeRx.ValueRx<TValue, TCharge>,
+  to: URIChargeTarget<TValue, TCharge>,
+  rx: AnyURIChargeRx<TValue, TCharge>,
+  key: string,
   input: string,
   offset: number,
   sign: <T extends number | bigint>(value: T) => T,
 ): TCharge {
   if (input[offset + 1] === 'n') {
-    return rx.setValue(
+    return to.setValue(
+      rx,
+      key,
       sign(input.length < offset + 3 ? 0n : BigInt(input.slice(offset + 2))),
       'bigint',
     );
   }
 
-  return rx.setValue(sign(input.length < offset + 3 ? 0 : Number(input.slice(offset))), 'number');
+  return to.setValue(
+    rx,
+    key,
+    sign(input.length < offset + 3 ? 0 : Number(input.slice(offset))),
+    'number',
+  );
 }

--- a/src/charge/impl/ch-uri-value-decoder.ts
+++ b/src/charge/impl/ch-uri-value-decoder.ts
@@ -1,9 +1,14 @@
-import { URIChargeTarget } from './uri-charge-target.js';
+import { URIChargeRx } from '../uri-charge-rx.js';
+import { URIChargeExtParser } from './uri-charge-ext-parser.js';
 
 export interface ChURIValueDecoder {
   decodeKey(rawKey: string): string;
   decodeString(rawString: string): string;
-  decodeValue<TValue, TCharge>(to: URIChargeTarget<TValue, TCharge>, input: string): TCharge;
+  decodeValue<TValue, TCharge>(
+    rx: URIChargeRx.ValueRx<TValue, TCharge>,
+    ext: URIChargeExtParser<TValue, TCharge>,
+    input: string,
+  ): TCharge;
 }
 
 export const defaultChURIValueDecoder: ChURIValueDecoder = {
@@ -17,21 +22,22 @@ function decodeChURIKey(rawKey: string): string {
 }
 
 function decodeChURIValue<TValue, TCharge>(
-  to: URIChargeTarget<TValue, TCharge>,
+  rx: URIChargeRx.ValueRx<TValue, TCharge>,
+  ext: URIChargeExtParser<TValue, TCharge>,
   input: string,
 ): TCharge {
   if (!input) {
     // Empty string treated as is.
-    return to.rx.setValue('', 'string');
+    return rx.setValue('', 'string');
   }
 
   const decoder = CHURI_VALUE_DECODERS[input[0]];
 
   if (decoder) {
-    return decoder(to, input);
+    return decoder(rx, ext, input);
   }
 
-  return decodeStringChURIValue(to, input);
+  return decodeStringChURIValue(rx, input);
 }
 
 export type ChURIValuePrefix =
@@ -51,7 +57,8 @@ export type ChURIValuePrefix =
 
 const CHURI_VALUE_DECODERS: {
   readonly [prefix: string]: <TValue, TCharge>(
-    to: URIChargeTarget<TValue, TCharge>,
+    rx: URIChargeRx.ValueRx<TValue, TCharge>,
+    ext: URIChargeExtParser<TValue, TCharge>,
     input: string,
   ) => TCharge;
 } = {
@@ -71,65 +78,70 @@ const CHURI_VALUE_DECODERS: {
 } satisfies { readonly [prefix in ChURIValuePrefix]: unknown };
 
 function decodeExclamationPrefixedChURIValue<TValue, TCharge>(
-  to: URIChargeTarget<TValue, TCharge>,
+  rx: URIChargeRx.ValueRx<TValue, TCharge>,
+  ext: URIChargeExtParser<TValue, TCharge>,
   input: string,
 ): TCharge {
   if (input.length === 1) {
-    return to.rx.setValue(true, 'boolean');
+    return rx.setValue(true, 'boolean');
   }
   if (input === '!!') {
-    return to.rx.rxList(rx => rx.endList());
+    return rx.rxList(rx => rx.endList());
   }
 
-  return to.ext.addEntity(to, input);
+  return ext.addEntity(rx, input);
 }
 
 function decodeMinusSignedChURIValue<TValue, TCharge>(
-  to: URIChargeTarget<TValue, TCharge>,
+  rx: URIChargeRx.ValueRx<TValue, TCharge>,
+  _ext: URIChargeExtParser<TValue, TCharge>,
   input: string,
 ): TCharge {
   if (input.length === 1) {
-    return to.rx.setValue(false, 'boolean');
+    return rx.setValue(false, 'boolean');
   }
   if (input === '--') {
-    return to.rx.setValue(null, 'null');
+    return rx.setValue(null, 'null');
   }
 
   const secondChar = input[1];
 
   if (secondChar >= '0' && secondChar <= '9') {
-    return decodeNumericChURIValue(to, input, 1, negate);
+    return decodeNumericChURIValue(rx, input, 1, negate);
   }
 
-  return decodeStringChURIValue(to, input);
+  return decodeStringChURIValue(rx, input);
 }
 
 function decodeNumberChURIValue<TValue, TCharge>(
-  { rx }: URIChargeTarget<TValue, TCharge>,
+  rx: URIChargeRx.ValueRx<TValue, TCharge>,
+  _ext: URIChargeExtParser<TValue, TCharge>,
   input: string,
 ): TCharge {
   return rx.setValue(Number(input), 'number');
 }
 
 function decodeQuotedChURIValue<TValue, TCharge>(
-  { decoder, rx: rx }: URIChargeTarget<TValue, TCharge>,
+  rx: URIChargeRx.ValueRx<TValue, TCharge>,
+  _ext: URIChargeExtParser<TValue, TCharge>,
   input: string,
 ): TCharge {
-  return rx.setValue(decoder.decodeString(input.slice(1)), 'string');
+  return rx.setValue(decodeURIComponent(input.slice(1)), 'string');
 }
 
 function decodeStringChURIValue<TValue, TCharge>(
-  { decoder, rx }: URIChargeTarget<TValue, TCharge>,
+  rx: URIChargeRx.ValueRx<TValue, TCharge>,
   input: string,
 ): TCharge {
-  return rx.setValue(decoder.decodeString(input), 'string');
+  return rx.setValue(decodeURIComponent(input), 'string');
 }
 
 function decodeUnsignedChURIValue<TValue, TCharge>(
-  to: URIChargeTarget<TValue, TCharge>,
+  rx: URIChargeRx.ValueRx<TValue, TCharge>,
+  _ext: URIChargeExtParser<TValue, TCharge>,
   input: string,
 ): TCharge {
-  return decodeNumericChURIValue(to, input, 0, asis);
+  return decodeNumericChURIValue(rx, input, 0, asis);
 }
 
 function negate<T extends number | bigint>(value: T): T {
@@ -141,7 +153,7 @@ function asis<T extends number | bigint>(value: T): T {
 }
 
 function decodeNumericChURIValue<TValue, TCharge>(
-  { rx }: URIChargeTarget<TValue, TCharge>,
+  rx: URIChargeRx.ValueRx<TValue, TCharge>,
   input: string,
   offset: number,
   sign: <T extends number | bigint>(value: T) => T,

--- a/src/charge/impl/ch-uri-value-decoder.ts
+++ b/src/charge/impl/ch-uri-value-decoder.ts
@@ -15,10 +15,6 @@ export const defaultChURIValueDecoder: ChURIValueDecoder = {
   decodeValue: decodeChURIValue,
 };
 
-export function decodeChURIKey(rawKey: string): string {
-  return decodeURIComponent(rawKey.startsWith("'") ? rawKey.slice(1) : rawKey);
-}
-
 function decodeChURIValue<TValue, TCharge>(
   rx: URIChargeRx.ValueRx<TValue, TCharge>,
   ext: URIChargeExtParser<TValue, TCharge>,

--- a/src/charge/impl/ch-uri-value-decoder.ts
+++ b/src/charge/impl/ch-uri-value-decoder.ts
@@ -78,7 +78,7 @@ function decodeExclamationPrefixedChURIValue<TValue, TCharge>(
     return to.rx.setValue(true, 'boolean');
   }
   if (input === '!!') {
-    return to.rx.startList().endList();
+    return to.rx.rxList(rx => rx.endList());
   }
 
   return to.ext.addEntity(to, input);

--- a/src/charge/impl/ch-uri-value-decoder.ts
+++ b/src/charge/impl/ch-uri-value-decoder.ts
@@ -1,21 +1,13 @@
 import { URIChargeRx } from '../uri-charge-rx.js';
 import { URIChargeExtParser } from './uri-charge-ext-parser.js';
 
-export interface ChURIValueDecoder {
-  decodeString(rawString: string): string;
-  decodeValue<TValue, TCharge>(
-    rx: URIChargeRx.ValueRx<TValue, TCharge>,
-    ext: URIChargeExtParser<TValue, TCharge>,
-    input: string,
-  ): TCharge;
-}
+export type ChURIValueDecoder = <TValue, TCharge>(
+  rx: URIChargeRx.ValueRx<TValue, TCharge>,
+  ext: URIChargeExtParser<TValue, TCharge>,
+  input: string,
+) => TCharge;
 
-export const defaultChURIValueDecoder: ChURIValueDecoder = {
-  decodeString: decodeURIComponent,
-  decodeValue: decodeChURIValue,
-};
-
-function decodeChURIValue<TValue, TCharge>(
+export function decodeChURIValue<TValue, TCharge>(
   rx: URIChargeRx.ValueRx<TValue, TCharge>,
   ext: URIChargeExtParser<TValue, TCharge>,
   input: string,

--- a/src/charge/impl/parse-ch-uri-value.ts
+++ b/src/charge/impl/parse-ch-uri-value.ts
@@ -1,6 +1,6 @@
+import { decodeURIChargeKey } from '../uri-charge-codec.js';
 import { URIChargeParser } from '../uri-charge-parser.js';
 import { URIChargeRx } from '../uri-charge-rx.js';
-import { decodeChURIKey } from './ch-uri-value-decoder.js';
 import { ChURIItemTarget, ChURIMapEntryTarget, URIChargeTarget } from './uri-charge-target.js';
 
 export function parseChURIValue<TValue, TCharge>(
@@ -70,7 +70,7 @@ function parseChURIMapOrDirective<TValue, TCharge>(
   // Start nested map and parse first entry.
   const firstValueOffset = rawKey.length + 1;
   const firstValueInput = input.slice(firstValueOffset);
-  const firstKey = decodeChURIKey(rawKey);
+  const firstKey = decodeURIChargeKey(rawKey);
   let end!: number;
   const charge = to.rx.rxMap(mapRx => {
     end =
@@ -147,7 +147,7 @@ function parseChURIMapEntries<TValue>(
     const keyEnd = input.search(PARENT_PATTERN);
 
     if (keyEnd < 0) {
-      to.forKey(decodeChURIKey(input)).addSuffix();
+      to.forKey(decodeURIChargeKey(input)).addSuffix();
 
       return offset + input.length;
     }
@@ -155,7 +155,7 @@ function parseChURIMapEntries<TValue>(
     if (keyEnd) {
       // New key specified explicitly.
       // Otherwise, the previous one reused. Thus, `key(value1)(value2)` is the same as `key(value1)key(value2)`.
-      to = to.forKey(decodeChURIKey(input.slice(0, keyEnd)));
+      to = to.forKey(decodeURIChargeKey(input.slice(0, keyEnd)));
     }
     if (input[keyEnd] === ')') {
       if (keyEnd) {
@@ -265,7 +265,7 @@ function parseChURIListItems<TValue>(
       // Suffix treated as trailing item containing map with suffix.
       // Thus, `(value)suffix` is the same as `(value)(suffix())`.
       to.rxMap(suffixRx => {
-        suffixRx.addSuffix(decodeChURIKey(input));
+        suffixRx.addSuffix(decodeURIChargeKey(input));
 
         return suffixRx.endMap();
       });

--- a/src/charge/impl/parse-ch-uri-value.ts
+++ b/src/charge/impl/parse-ch-uri-value.ts
@@ -1,5 +1,6 @@
 import { URIChargeParser } from '../uri-charge-parser.js';
 import { URIChargeRx } from '../uri-charge-rx.js';
+import { decodeChURIKey } from './ch-uri-value-decoder.js';
 import { ChURIItemTarget, ChURIMapEntryTarget, URIChargeTarget } from './uri-charge-target.js';
 
 export function parseChURIValue<TValue, TCharge>(
@@ -69,7 +70,7 @@ function parseChURIMapOrDirective<TValue, TCharge>(
   // Start nested map and parse first entry.
   const firstValueOffset = rawKey.length + 1;
   const firstValueInput = input.slice(firstValueOffset);
-  const firstKey = to.decoder.decodeKey(rawKey);
+  const firstKey = decodeChURIKey(rawKey);
   let end!: number;
   const charge = to.rx.rxMap(mapRx => {
     end =
@@ -146,7 +147,7 @@ function parseChURIMapEntries<TValue>(
     const keyEnd = input.search(PARENT_PATTERN);
 
     if (keyEnd < 0) {
-      to.forKey(to.decoder.decodeKey(input)).addSuffix();
+      to.forKey(decodeChURIKey(input)).addSuffix();
 
       return offset + input.length;
     }
@@ -154,7 +155,7 @@ function parseChURIMapEntries<TValue>(
     if (keyEnd) {
       // New key specified explicitly.
       // Otherwise, the previous one reused. Thus, `key(value1)(value2)` is the same as `key(value1)key(value2)`.
-      to = to.forKey(to.decoder.decodeKey(input.slice(0, keyEnd)));
+      to = to.forKey(decodeChURIKey(input.slice(0, keyEnd)));
     }
     if (input[keyEnd] === ')') {
       if (keyEnd) {
@@ -264,7 +265,7 @@ function parseChURIListItems<TValue>(
       // Suffix treated as trailing item containing map with suffix.
       // Thus, `(value)suffix` is the same as `(value)(suffix())`.
       to.rxMap(suffixRx => {
-        suffixRx.addSuffix(to.decoder.decodeKey(input));
+        suffixRx.addSuffix(decodeChURIKey(input));
 
         return suffixRx.endMap();
       });

--- a/src/charge/impl/parse-ch-uri-value.ts
+++ b/src/charge/impl/parse-ch-uri-value.ts
@@ -6,7 +6,7 @@ import {
   decodeChURIDirectiveArg,
   decodeChURIValue,
 } from './ch-uri-value-decoder.js';
-import { ChURIItemTarget, ChURIMapEntryTarget, URIChargeTarget } from './uri-charge-target.js';
+import { ChURIEntryTarget, ChURIItemTarget, URIChargeTarget } from './uri-charge-target.js';
 
 export function parseChURIValue<TValue, TCharge>(
   to: URIChargeTarget<TValue, TCharge>,
@@ -126,7 +126,7 @@ function parseChURIMap<TValue>(
 ): number {
   // Opening parent after key.
 
-  const to = new ChURIMapEntryTarget(parent, key, mapRx);
+  const to = new ChURIEntryTarget(parent, key, mapRx);
 
   // Parse first entry value.
   const firstValueEnd = parseChURIValue(to, decodeChURIValue, firstValueInput).end + 1; // After closing parent.
@@ -144,7 +144,7 @@ function parseChURIMap<TValue>(
 }
 
 function parseChURIMapEntries<TValue>(
-  to: ChURIMapEntryTarget<TValue>,
+  to: ChURIEntryTarget<TValue>,
   input: string /* never empty */,
 ): number {
   let offset = 0;

--- a/src/charge/impl/parse-ch-uri-value.ts
+++ b/src/charge/impl/parse-ch-uri-value.ts
@@ -11,12 +11,12 @@ export function parseChURIValue<TValue, TCharge>(
 
   if (valueEnd < 0) {
     // Up to the end of input.
-    return { charge: to.decoder.decodeValue(to.rx, to.ext, input), end: input.length };
+    return { charge: to.decoder(to.rx, to.ext, input), end: input.length };
   }
   if (input[valueEnd] === ')') {
     // Up to closing parent.
     return {
-      charge: to.decoder.decodeValue(to.rx, to.ext, input.slice(0, valueEnd)),
+      charge: to.decoder(to.rx, to.ext, input.slice(0, valueEnd)),
       end: valueEnd,
     };
   }

--- a/src/charge/impl/parse-ch-uri-value.ts
+++ b/src/charge/impl/parse-ch-uri-value.ts
@@ -10,11 +10,14 @@ export function parseChURIValue<TValue, TCharge>(
 
   if (valueEnd < 0) {
     // Up to the end of input.
-    return { charge: to.decoder.decodeValue(to, input), end: input.length };
+    return { charge: to.decoder.decodeValue(to.rx, to.ext, input), end: input.length };
   }
   if (input[valueEnd] === ')') {
     // Up to closing parent.
-    return { charge: to.decoder.decodeValue(to, input.slice(0, valueEnd)), end: valueEnd };
+    return {
+      charge: to.decoder.decodeValue(to.rx, to.ext, input.slice(0, valueEnd)),
+      end: valueEnd,
+    };
   }
 
   // Opening parent.
@@ -52,7 +55,7 @@ function parseChURIMapOrDirective<TValue, TCharge>(
     const firstValueOffset = rawKey.length + 1;
     const firstValueInput = input.slice(firstValueOffset);
     let end!: number;
-    const charge = to.ext.rxDirective(to, rawKey, directiveRx => {
+    const charge = to.ext.rxDirective(to.rx, rawKey, directiveRx => {
       end =
         firstValueOffset
         + parseChURIDirective(to as URIChargeTarget<TValue>, directiveRx, firstValueInput);

--- a/src/charge/impl/parse-ch-uri-value.ts
+++ b/src/charge/impl/parse-ch-uri-value.ts
@@ -10,11 +10,11 @@ export function parseChURIValue<TValue, TCharge>(
 
   if (valueEnd < 0) {
     // Up to the end of input.
-    return { charge: to.decode(input), end: input.length };
+    return { charge: to.decoder.decodeValue(to, input), end: input.length };
   }
   if (input[valueEnd] === ')') {
     // Up to closing parent.
-    return { charge: to.decode(input.slice(0, valueEnd)), end: valueEnd };
+    return { charge: to.decoder.decodeValue(to, input.slice(0, valueEnd)), end: valueEnd };
   }
 
   // Opening parent.

--- a/src/charge/impl/parse-ch-uri-value.ts
+++ b/src/charge/impl/parse-ch-uri-value.ts
@@ -17,12 +17,12 @@ export function parseChURIValue<TValue, TCharge>(
 
   if (valueEnd < 0) {
     // Up to the end of input.
-    return { charge: decoder(to.rx, to.ext, input), end: input.length };
+    return { charge: decoder(to, input), end: input.length };
   }
   if (input[valueEnd] === ')') {
     // Up to closing parent.
     return {
-      charge: decoder(to.rx, to.ext, input.slice(0, valueEnd)),
+      charge: decoder(to, input.slice(0, valueEnd)),
       end: valueEnd,
     };
   }
@@ -35,7 +35,7 @@ export function parseChURIValue<TValue, TCharge>(
   // Empty key. Start nested list and parse first item.
 
   let end!: number;
-  const charge = to.rx.rxList(listRx => {
+  const charge = to.rxList(listRx => {
     end = parseChURIList(to as URIChargeTarget<TValue>, listRx, input.slice(1)) + 1;
 
     return listRx.endList();
@@ -62,7 +62,7 @@ function parseChURIMapOrDirective<TValue, TCharge>(
     const firstValueOffset = rawKey.length + 1;
     const firstValueInput = input.slice(firstValueOffset);
     let end!: number;
-    const charge = to.ext.rxDirective(to.rx, rawKey, directiveRx => {
+    const charge = to.rxDirective(rawKey, directiveRx => {
       end =
         firstValueOffset
         + parseChURIDirective(to as URIChargeTarget<TValue>, directiveRx, firstValueInput);
@@ -78,7 +78,7 @@ function parseChURIMapOrDirective<TValue, TCharge>(
   const firstValueInput = input.slice(firstValueOffset);
   const firstKey = decodeURIChargeKey(rawKey);
   let end!: number;
-  const charge = to.rx.rxMap(mapRx => {
+  const charge = to.rxMap(mapRx => {
     end =
       firstValueOffset
       + parseChURIMap(to as URIChargeTarget<TValue>, firstKey, mapRx, firstValueInput);
@@ -115,7 +115,7 @@ function parseChURIEmptyMap<TValue, TCharge>(
     end = input.length;
   }
 
-  return { charge: to.rx.rxMap(mapRx => mapRx.endMap()), end };
+  return { charge: to.rxMap(mapRx => mapRx.endMap()), end };
 }
 
 function parseChURIMap<TValue>(

--- a/src/charge/impl/uri-charge-ext-parser.ts
+++ b/src/charge/impl/uri-charge-ext-parser.ts
@@ -1,7 +1,6 @@
 import { asArray } from '@proc7ts/primitives';
 import { URIChargeExt } from '../uri-charge-ext.js';
 import { URIChargeRx } from '../uri-charge-rx.js';
-import { URIChargeTarget } from './uri-charge-target.js';
 
 export class URIChargeExtParser<out TValue, out TCharge = unknown> {
 
@@ -30,39 +29,20 @@ export class URIChargeExtParser<out TValue, out TCharge = unknown> {
     }
   }
 
-  addEntity(to: URIChargeTarget<TValue, TCharge>, rawEntity: string): TCharge {
+  addEntity(rx: URIChargeRx.ValueRx<TValue, TCharge>, rawEntity: string): TCharge {
     const entityHandler = this.#entities.get(rawEntity);
 
-    return entityHandler
-      ? entityHandler(new URIChargeExtContext(to), rawEntity)
-      : to.rx.setEntity(rawEntity);
+    return entityHandler ? entityHandler(rx, rawEntity) : rx.setEntity(rawEntity);
   }
 
   rxDirective(
-    to: URIChargeTarget<TValue, TCharge>,
+    rx: URIChargeRx.ValueRx<TValue, TCharge>,
     rawName: string,
     parse: (rx: URIChargeRx.DirectiveRx<TValue, TCharge>) => TCharge,
   ): TCharge {
     const handler = this.#directives.get(rawName);
 
-    return handler
-      ? handler(new URIChargeExtContext(to), rawName, parse)
-      : to.rx.rxDirective(rawName, parse);
-  }
-
-}
-
-class URIChargeExtContext<out TValue, out TCharge>
-  implements URIChargeExt.Context<TValue, TCharge> {
-
-  readonly #to: URIChargeTarget<TValue, TCharge>;
-
-  constructor(to: URIChargeTarget<TValue, TCharge>) {
-    this.#to = to;
-  }
-
-  get rx(): URIChargeRx.ValueRx<TValue, TCharge> {
-    return this.#to.rx;
+    return handler ? handler(rx, rawName, parse) : rx.rxDirective(rawName, parse);
   }
 
 }

--- a/src/charge/impl/uri-charge-ext-parser.ts
+++ b/src/charge/impl/uri-charge-ext-parser.ts
@@ -12,7 +12,7 @@ export class URIChargeExtParser<out TValue, out TCharge = unknown> {
   readonly #chargeRx: URIChargeRx<TValue, TCharge>;
   readonly #specs: URIChargeExt.Factory<TValue, TCharge>[];
 
-  #entities?: Map<string, URIChargeExt.EntityHandler<TValue, TCharge>>;
+  #entities?: Map<string, URIChargeExt.EntityHandler<TCharge>>;
   #directives?: Map<string, URIChargeExt.DirectiveHandler<TValue, TCharge>>;
 
   #valueTarget?: URIChargeValueTarget<TValue, TCharge>;
@@ -51,11 +51,7 @@ export class URIChargeExtParser<out TValue, out TCharge = unknown> {
     }
   }
 
-  get chargeRx(): URIChargeRx<TValue, TCharge> {
-    return this.#chargeRx;
-  }
-
-  forEntity(rawEntity: string): URIChargeExt.EntityHandler<TValue, TCharge> | undefined {
+  forEntity(rawEntity: string): URIChargeExt.EntityHandler<TCharge> | undefined {
     this.#init();
 
     return this.#entities!.get(rawEntity);

--- a/src/charge/impl/uri-charge-ext-parser.ts
+++ b/src/charge/impl/uri-charge-ext-parser.ts
@@ -29,20 +29,12 @@ export class URIChargeExtParser<out TValue, out TCharge = unknown> {
     }
   }
 
-  addEntity(rx: URIChargeRx.ValueRx<TValue, TCharge>, rawEntity: string): TCharge {
-    const entityHandler = this.#entities.get(rawEntity);
-
-    return entityHandler ? entityHandler(rx, rawEntity) : rx.setEntity(rawEntity);
+  forEntity(rawEntity: string): URIChargeExt.EntityHandler<TValue, TCharge> | undefined {
+    return this.#entities.get(rawEntity);
   }
 
-  rxDirective(
-    rx: URIChargeRx.ValueRx<TValue, TCharge>,
-    rawName: string,
-    parse: (rx: URIChargeRx.DirectiveRx<TValue, TCharge>) => TCharge,
-  ): TCharge {
-    const handler = this.#directives.get(rawName);
-
-    return handler ? handler(rx, rawName, parse) : rx.rxDirective(rawName, parse);
+  forDirective(rawName: string): URIChargeExt.DirectiveHandler<TValue, TCharge> | undefined {
+    return this.#directives.get(rawName);
   }
 
 }

--- a/src/charge/impl/uri-charge-ext-parser.ts
+++ b/src/charge/impl/uri-charge-ext-parser.ts
@@ -38,14 +38,16 @@ export class URIChargeExtParser<out TValue, out TCharge = unknown> {
       : to.rx.setEntity(rawEntity);
   }
 
-  startDirective(
+  rxDirective(
     to: URIChargeTarget<TValue, TCharge>,
     rawName: string,
-  ): URIChargeRx.DirectiveRx<TValue, TCharge> {
-    return (
-      this.#directives.get(rawName)?.(new URIChargeExtContext(to), rawName)
-      ?? to.rx.startDirective(rawName)
-    );
+    parse: (rx: URIChargeRx.DirectiveRx<TValue, TCharge>) => TCharge,
+  ): TCharge {
+    const handler = this.#directives.get(rawName);
+
+    return handler
+      ? handler(new URIChargeExtContext(to), rawName, parse)
+      : to.rx.rxDirective(rawName, parse);
   }
 
 }

--- a/src/charge/impl/uri-charge-target.ts
+++ b/src/charge/impl/uri-charge-target.ts
@@ -7,8 +7,6 @@ export interface URIChargeTarget<out TValue, out TCharge = unknown> {
   readonly decoder: ChURIValueDecoder;
   readonly rx: URIChargeRx.ValueRx<TValue, TCharge>;
   readonly ext: URIChargeExtParser<TValue, TCharge>;
-
-  decode(input: string): TCharge;
 }
 
 export class ChURIMapEntryTarget<out TValue>
@@ -45,10 +43,6 @@ export class ChURIMapEntryTarget<out TValue>
 
   get ext(): URIChargeExtParser<TValue> {
     return this.#ext;
-  }
-
-  decode(input: string): unknown {
-    return this.#decoder.decodeValue(this, input);
   }
 
   forKey(key: string): ChURIMapEntryTarget<TValue> {
@@ -112,10 +106,6 @@ export class ChURIItemTarget<out TValue>
 
   get ext(): URIChargeExtParser<TValue> {
     return this.#ext;
-  }
-
-  decode(input: string): unknown {
-    return this.#decoder.decodeValue(this, input);
   }
 
   set(charge: unknown): unknown {

--- a/src/charge/impl/uri-charge-target.ts
+++ b/src/charge/impl/uri-charge-target.ts
@@ -29,11 +29,7 @@ export abstract class URIChargeTarget<
     const handler = this.#ext.forEntity(rawEntity);
 
     if (handler) {
-      return this.set(
-        rx,
-        key,
-        this.#ext.chargeRx.rxValue(rx => handler(rx, rawEntity)),
-      );
+      return this.set(rx, key, handler(rawEntity));
     }
 
     return this._setEntity(rx, key, rawEntity);
@@ -64,11 +60,7 @@ export abstract class URIChargeTarget<
     const handler = this.#ext.forDirective(rawName);
 
     if (handler) {
-      return this.set(
-        rx,
-        key,
-        this.#ext.chargeRx.rxValue(rx => handler(rx, rawName, parse)),
-      );
+      return this.set(rx, key, handler(rawName, parse));
     }
 
     return this._rxDirective(rx, key, rawName, parse);

--- a/src/charge/impl/uri-charge-target.ts
+++ b/src/charge/impl/uri-charge-target.ts
@@ -7,7 +7,7 @@ export interface URIChargeTarget<out TValue, out TCharge = unknown> {
   readonly ext: URIChargeExtParser<TValue, TCharge>;
 }
 
-export class ChURIMapEntryTarget<out TValue>
+export class ChURIEntryTarget<out TValue>
   implements URIChargeTarget<TValue>, URIChargeRx.ValueRx<TValue> {
 
   readonly #key: string;
@@ -32,8 +32,8 @@ export class ChURIMapEntryTarget<out TValue>
     return this.#ext;
   }
 
-  forKey(key: string): ChURIMapEntryTarget<TValue> {
-    return new ChURIMapEntryTarget(this, key, this.#mapRx);
+  forKey(key: string): ChURIEntryTarget<TValue> {
+    return new ChURIEntryTarget(this, key, this.#mapRx);
   }
 
   set(charge: unknown): void {

--- a/src/charge/impl/uri-charge-target.ts
+++ b/src/charge/impl/uri-charge-target.ts
@@ -1,10 +1,8 @@
 import { ChURIPrimitive } from '../ch-uri-value.js';
 import { URIChargeRx } from '../uri-charge-rx.js';
-import { ChURIValueDecoder } from './ch-uri-value-decoder.js';
 import { URIChargeExtParser } from './uri-charge-ext-parser.js';
 
 export interface URIChargeTarget<out TValue, out TCharge = unknown> {
-  readonly decoder: ChURIValueDecoder;
   readonly rx: URIChargeRx.ValueRx<TValue, TCharge>;
   readonly ext: URIChargeExtParser<TValue, TCharge>;
 }
@@ -14,27 +12,16 @@ export class ChURIMapEntryTarget<out TValue>
 
   readonly #key: string;
   readonly #mapRx: URIChargeRx.MapRx<TValue>;
-  readonly #decoder: ChURIValueDecoder;
   readonly #ext: URIChargeExtParser<TValue>;
 
-  constructor(
-    parent: URIChargeTarget<TValue>,
-    key: string,
-    mapRx: URIChargeRx.MapRx<TValue>,
-    decoder: ChURIValueDecoder = parent.decoder,
-  ) {
+  constructor(parent: URIChargeTarget<TValue>, key: string, mapRx: URIChargeRx.MapRx<TValue>) {
     this.#key = key;
     this.#mapRx = mapRx;
-    this.#decoder = decoder;
     this.#ext = parent.ext;
   }
 
   get chargeRx(): URIChargeRx<TValue> {
     return this.#mapRx.chargeRx;
-  }
-
-  get decoder(): ChURIValueDecoder {
-    return this.#decoder;
   }
 
   get rx(): URIChargeRx.ValueRx<TValue> {
@@ -82,12 +69,10 @@ export class ChURIMapEntryTarget<out TValue>
 export class ChURIItemTarget<out TValue>
   implements URIChargeTarget<TValue>, URIChargeRx.ValueRx<TValue> {
 
-  readonly #decoder: ChURIValueDecoder;
   readonly #ext: URIChargeExtParser<TValue, unknown>;
   readonly #itemsRx: URIChargeRx.ItemsRx<TValue>;
 
   constructor(parent: URIChargeTarget<TValue>, itemsRx: URIChargeRx.ItemsRx<TValue>) {
-    this.#decoder = parent.decoder;
     this.#ext = parent.ext;
     this.#itemsRx = itemsRx;
   }
@@ -98,10 +83,6 @@ export class ChURIItemTarget<out TValue>
 
   get rx(): this {
     return this;
-  }
-
-  get decoder(): ChURIValueDecoder {
-    return this.#decoder;
   }
 
   get ext(): URIChargeExtParser<TValue> {

--- a/src/charge/impl/uri-charge-target.ts
+++ b/src/charge/impl/uri-charge-target.ts
@@ -67,8 +67,8 @@ export class ChURIMapEntryTarget<out TValue>
     this.#mapRx.putValue(this.#key, value, type);
   }
 
-  startMap(): URIChargeRx.MapRx<TValue> {
-    return this.#mapRx.startMap(this.#key);
+  rxMap(parse: (rx: URIChargeRx.MapRx<TValue>) => void): void {
+    this.#mapRx.rxMap(this.#key, parse);
   }
 
   startList(): URIChargeRx.ListRx<TValue> {
@@ -128,8 +128,8 @@ abstract class ChURIItemTarget<out TValue, TRx extends URIChargeRx.ItemsRx<TValu
     this.itemsRx.addValue(value, type);
   }
 
-  startMap(): URIChargeRx.MapRx<TValue> {
-    return this.itemsRx.startMap();
+  rxMap(parse: (rx: URIChargeRx.MapRx<TValue>) => void): void {
+    this.itemsRx.rxMap(parse);
   }
 
   startList(): URIChargeRx.ListRx<TValue> {

--- a/src/charge/impl/uri-charge-target.ts
+++ b/src/charge/impl/uri-charge-target.ts
@@ -71,12 +71,12 @@ export class ChURIMapEntryTarget<out TValue>
     this.#mapRx.rxMap(this.#key, parse);
   }
 
-  startList(): URIChargeRx.ListRx<TValue> {
-    return this.#mapRx.startList(this.#key);
+  rxList(parse: (rx: URIChargeRx.ListRx<TValue>) => void): void {
+    this.#mapRx.rxList(this.#key, parse);
   }
 
-  startDirective(rawName: string): URIChargeRx.DirectiveRx<TValue> {
-    return this.#mapRx.startDirective(this.#key, rawName);
+  rxDirective(rawName: string, parse: (rx: URIChargeRx.DirectiveRx<TValue>) => void): void {
+    this.#mapRx.rxDirective(this.#key, rawName, parse);
   }
 
   addSuffix(): void {
@@ -85,19 +85,21 @@ export class ChURIMapEntryTarget<out TValue>
 
 }
 
-abstract class ChURIItemTarget<out TValue, TRx extends URIChargeRx.ItemsRx<TValue>>
+export class ChURIItemTarget<out TValue>
   implements URIChargeTarget<TValue>, URIChargeRx.ValueRx<TValue> {
 
   readonly #decoder: ChURIValueDecoder;
   readonly #ext: URIChargeExtParser<TValue, unknown>;
+  readonly #itemsRx: URIChargeRx.ItemsRx<TValue>;
 
-  constructor(parent: URIChargeTarget<TValue>, protected readonly itemsRx: TRx) {
+  constructor(parent: URIChargeTarget<TValue>, itemsRx: URIChargeRx.ItemsRx<TValue>) {
     this.#decoder = parent.decoder;
     this.#ext = parent.ext;
+    this.#itemsRx = itemsRx;
   }
 
   get chargeRx(): URIChargeRx<TValue> {
-    return this.itemsRx.chargeRx;
+    return this.#itemsRx.chargeRx;
   }
 
   get rx(): this {
@@ -117,43 +119,27 @@ abstract class ChURIItemTarget<out TValue, TRx extends URIChargeRx.ItemsRx<TValu
   }
 
   set(charge: unknown): unknown {
-    return this.itemsRx.add(charge);
+    return this.#itemsRx.add(charge);
   }
 
   setEntity(rawEntity: string): void {
-    this.itemsRx.addEntity(rawEntity);
+    this.#itemsRx.addEntity(rawEntity);
   }
 
   setValue(value: ChURIPrimitive | TValue, type: string): void {
-    this.itemsRx.addValue(value, type);
+    this.#itemsRx.addValue(value, type);
   }
 
   rxMap(parse: (rx: URIChargeRx.MapRx<TValue>) => void): void {
-    this.itemsRx.rxMap(parse);
+    this.#itemsRx.rxMap(parse);
   }
 
-  startList(): URIChargeRx.ListRx<TValue> {
-    return this.itemsRx.startList();
+  rxList(parse: (rx: URIChargeRx.ListRx<TValue>) => void): void {
+    this.#itemsRx.rxList(parse);
   }
 
-  startDirective(rawName: string): URIChargeRx.DirectiveRx<TValue> {
-    return this.itemsRx.startDirective(rawName);
-  }
-
-}
-
-export class ChURIListItemTarget<out TValue> extends ChURIItemTarget<
-  TValue,
-  URIChargeRx.ListRx<TValue>
-> {
-
-  endList(): void {
-    this.itemsRx.endList();
+  rxDirective(rawName: string, parse: (rx: URIChargeRx.DirectiveRx<TValue>) => void): void {
+    this.#itemsRx.rxDirective(rawName, parse);
   }
 
 }
-
-export class ChURIDirectiveArgsTarget<out TValue> extends ChURIItemTarget<
-  TValue,
-  URIChargeRx.DirectiveRx<TValue>
-> {}

--- a/src/charge/impl/uri-charge-target.ts
+++ b/src/charge/impl/uri-charge-target.ts
@@ -2,114 +2,183 @@ import { ChURIPrimitive } from '../ch-uri-value.js';
 import { URIChargeRx } from '../uri-charge-rx.js';
 import { URIChargeExtParser } from './uri-charge-ext-parser.js';
 
-export interface URIChargeTarget<out TValue, out TCharge = unknown> {
-  readonly rx: URIChargeRx.ValueRx<TValue, TCharge>;
-  readonly ext: URIChargeExtParser<TValue, TCharge>;
+export abstract class URIChargeTarget<out TValue, out TCharge = unknown>
+  implements URIChargeRx.ValueRx<TValue, TCharge> {
+
+  readonly #chargeRx: URIChargeRx<TValue, TCharge>;
+  readonly #extParser: URIChargeExtParser<TValue, TCharge>;
+
+  constructor(
+    chargeRx: URIChargeRx<TValue, TCharge>,
+    extParser: URIChargeExtParser<TValue, TCharge>,
+  ) {
+    this.#chargeRx = chargeRx;
+    this.#extParser = extParser;
+  }
+
+  get chargeRx(): URIChargeRx<TValue, TCharge> {
+    return this.#chargeRx;
+  }
+
+  abstract set(charge: TCharge): TCharge;
+
+  setEntity(rawEntity: string): TCharge {
+    const handler = this.#extParser.forEntity(rawEntity);
+
+    return handler ? handler(this, rawEntity) : this._setEntity(rawEntity);
+  }
+
+  protected abstract _setEntity(rawEntity: string): TCharge;
+
+  abstract setValue(value: TValue | ChURIPrimitive, type: string): TCharge;
+
+  abstract rxMap(
+    parse: (rx: URIChargeRx.MapRx<TValue, TCharge, URIChargeRx<TValue, TCharge>>) => TCharge,
+  ): TCharge;
+
+  abstract rxList(
+    parse: (rx: URIChargeRx.ListRx<TValue, TCharge, URIChargeRx<TValue, TCharge>>) => TCharge,
+  ): TCharge;
+
+  rxDirective(
+    rawName: string,
+    parse: (rx: URIChargeRx.DirectiveRx<TValue, TCharge>) => TCharge,
+  ): TCharge {
+    const handler = this.#extParser.forDirective(rawName);
+
+    return handler ? handler(this, rawName, parse) : this._rxDirective(rawName, parse);
+  }
+
+  get _extParser(): URIChargeExtParser<TValue, TCharge> {
+    return this.#extParser;
+  }
+
+  protected abstract _rxDirective(
+    rawName: string,
+    parse: (rx: URIChargeRx.DirectiveRx<TValue, TCharge>) => TCharge,
+  ): TCharge;
+
 }
 
-export class ChURIEntryTarget<out TValue>
-  implements URIChargeTarget<TValue>, URIChargeRx.ValueRx<TValue> {
+export class ChURIValueTarget<out TValue, out TCharge> extends URIChargeTarget<TValue, TCharge> {
+
+  readonly #rx: URIChargeRx.ValueRx<TValue, TCharge>;
+
+  constructor(rx: URIChargeRx.ValueRx<TValue, TCharge>, ext: URIChargeExtParser<TValue, TCharge>) {
+    super(rx.chargeRx, ext);
+    this.#rx = rx;
+  }
+
+  override set(charge: TCharge): TCharge {
+    return this.#rx.set(charge);
+  }
+
+  override setValue(value: TValue | ChURIPrimitive, type: string): TCharge {
+    return this.#rx.setValue(value, type);
+  }
+
+  override rxMap(parse: (rx: URIChargeRx.MapRx<TValue, TCharge>) => TCharge): TCharge {
+    return this.#rx.rxMap(parse);
+  }
+
+  override rxList(parse: (rx: URIChargeRx.ListRx<TValue, TCharge>) => TCharge): TCharge {
+    return this.#rx.rxList(parse);
+  }
+
+  protected override _setEntity(rawEntity: string): TCharge {
+    return this.#rx.setEntity(rawEntity);
+  }
+
+  protected override _rxDirective(
+    rawName: string,
+    parse: (rx: URIChargeRx.DirectiveRx<TValue, TCharge>) => TCharge,
+  ): TCharge {
+    return this.#rx.rxDirective(rawName, parse);
+  }
+
+}
+
+export class ChURIEntryTarget<out TValue> extends URIChargeTarget<TValue> {
 
   readonly #key: string;
   readonly #mapRx: URIChargeRx.MapRx<TValue>;
-  readonly #ext: URIChargeExtParser<TValue>;
 
   constructor(parent: URIChargeTarget<TValue>, key: string, mapRx: URIChargeRx.MapRx<TValue>) {
+    super(parent.chargeRx, parent._extParser);
     this.#key = key;
     this.#mapRx = mapRx;
-    this.#ext = parent.ext;
-  }
-
-  get chargeRx(): URIChargeRx<TValue> {
-    return this.#mapRx.chargeRx;
-  }
-
-  get rx(): URIChargeRx.ValueRx<TValue> {
-    return this;
-  }
-
-  get ext(): URIChargeExtParser<TValue> {
-    return this.#ext;
   }
 
   forKey(key: string): ChURIEntryTarget<TValue> {
     return new ChURIEntryTarget(this, key, this.#mapRx);
   }
 
-  set(charge: unknown): void {
+  override set(charge: unknown): void {
     this.#mapRx.put(this.#key, charge);
   }
 
-  setEntity(rawEntity: string): void {
-    this.#mapRx.putEntity(this.#key, rawEntity);
-  }
-
-  setValue(value: ChURIPrimitive | TValue, type: string): void {
+  override setValue(value: ChURIPrimitive | TValue, type: string): void {
     this.#mapRx.putValue(this.#key, value, type);
   }
 
-  rxMap(parse: (rx: URIChargeRx.MapRx<TValue>) => void): void {
+  override rxMap(parse: (rx: URIChargeRx.MapRx<TValue>) => void): void {
     this.#mapRx.rxMap(this.#key, parse);
   }
 
-  rxList(parse: (rx: URIChargeRx.ListRx<TValue>) => void): void {
+  override rxList(parse: (rx: URIChargeRx.ListRx<TValue>) => void): void {
     this.#mapRx.rxList(this.#key, parse);
-  }
-
-  rxDirective(rawName: string, parse: (rx: URIChargeRx.DirectiveRx<TValue>) => void): void {
-    this.#mapRx.rxDirective(this.#key, rawName, parse);
   }
 
   addSuffix(): void {
     this.#mapRx.addSuffix(this.#key);
   }
 
+  protected override _setEntity(rawEntity: string): void {
+    this.#mapRx.putEntity(this.#key, rawEntity);
+  }
+
+  protected override _rxDirective(
+    rawName: string,
+    parse: (rx: URIChargeRx.DirectiveRx<TValue>) => void,
+  ): void {
+    this.#mapRx.rxDirective(this.#key, rawName, parse);
+  }
+
 }
 
-export class ChURIItemTarget<out TValue>
-  implements URIChargeTarget<TValue>, URIChargeRx.ValueRx<TValue> {
+export class ChURIItemTarget<out TValue> extends URIChargeTarget<TValue> {
 
-  readonly #ext: URIChargeExtParser<TValue, unknown>;
   readonly #itemsRx: URIChargeRx.ItemsRx<TValue>;
 
   constructor(parent: URIChargeTarget<TValue>, itemsRx: URIChargeRx.ItemsRx<TValue>) {
-    this.#ext = parent.ext;
+    super(parent.chargeRx, parent._extParser);
     this.#itemsRx = itemsRx;
   }
 
-  get chargeRx(): URIChargeRx<TValue> {
-    return this.#itemsRx.chargeRx;
-  }
-
-  get rx(): this {
-    return this;
-  }
-
-  get ext(): URIChargeExtParser<TValue> {
-    return this.#ext;
-  }
-
-  set(charge: unknown): unknown {
+  override set(charge: unknown): unknown {
     return this.#itemsRx.add(charge);
   }
 
-  setEntity(rawEntity: string): void {
-    this.#itemsRx.addEntity(rawEntity);
-  }
-
-  setValue(value: ChURIPrimitive | TValue, type: string): void {
+  override setValue(value: ChURIPrimitive | TValue, type: string): void {
     this.#itemsRx.addValue(value, type);
   }
 
-  rxMap(parse: (rx: URIChargeRx.MapRx<TValue>) => void): void {
+  override rxMap(parse: (rx: URIChargeRx.MapRx<TValue>) => void): void {
     this.#itemsRx.rxMap(parse);
   }
 
-  rxList(parse: (rx: URIChargeRx.ListRx<TValue>) => void): void {
+  override rxList(parse: (rx: URIChargeRx.ListRx<TValue>) => void): void {
     this.#itemsRx.rxList(parse);
   }
 
-  rxDirective(rawName: string, parse: (rx: URIChargeRx.DirectiveRx<TValue>) => void): void {
+  protected override _setEntity(rawEntity: string): void {
+    this.#itemsRx.addEntity(rawEntity);
+  }
+
+  protected override _rxDirective(
+    rawName: string,
+    parse: (rx: URIChargeRx.DirectiveRx<TValue>) => void,
+  ): void {
     this.#itemsRx.rxDirective(rawName, parse);
   }
 

--- a/src/charge/impl/uri-charge.some.ts
+++ b/src/charge/impl/uri-charge.some.ts
@@ -1,4 +1,4 @@
-import { encodeURICharge, encodeURIChargeList, encodeURIChargeMap } from '../encode-uri-charge.js';
+import { encodeURICharge, encodeURIChargeList, encodeURIChargeMap } from '../uri-charge-codec.js';
 import { URIChargeEncodable } from '../uri-charge-encodable.js';
 import { URICharge, URIChargeItem } from '../uri-charge.js';
 

--- a/src/charge/mod.ts
+++ b/src/charge/mod.ts
@@ -1,11 +1,16 @@
 export * from './ch-uri-value-builder.js';
 export * from './ch-uri-value.js';
-export { encodeURICharge, encodeURIChargeKey, encodeURIChargeList } from './encode-uri-charge.js';
 export * from './ext/mod.js';
 export * from './opaque.uri-charge-rx.js';
 export * from './parse-ch-uri-value.js';
 export * from './parse-uri-charge.js';
 export * from './uri-charge-builder.js';
+export {
+  decodeURIChargeKey,
+  encodeURICharge,
+  encodeURIChargeKey,
+  encodeURIChargeList,
+} from './uri-charge-codec.js';
 export * from './uri-charge-encodable.js';
 export * from './uri-charge-ext.js';
 export * from './uri-charge-parser.js';

--- a/src/charge/opaque-uri-charge-rx.spec.ts
+++ b/src/charge/opaque-uri-charge-rx.spec.ts
@@ -38,67 +38,75 @@ describe('OpaqueURIChargeRx', () => {
   });
 
   describe('MapRx', () => {
-    let rx: URIChargeRx.MapRx;
-    let received: unknown;
-
-    beforeEach(() => {
-      rx = chargeRx.rxMap(charge => {
-        received = charge;
-      });
-      received = undefined;
-    });
-
     describe('put', () => {
       it('ignores charge', () => {
-        rx.put('key', 'some');
+        expect(
+          chargeRx.rxMap(rx => {
+            rx.put('key', 'some');
 
-        expect(rx.endMap()).toBe(NONE);
-        expect(received).toBe(NONE);
+            return rx.endMap();
+          }),
+        ).toBe(NONE);
       });
     });
 
     describe('putEntity', () => {
       it('ignores entity', () => {
-        rx.putEntity('key', '!some');
+        expect(
+          chargeRx.rxMap(rx => {
+            rx.putEntity('key', '!some');
 
-        expect(rx.endMap()).toBe(NONE);
-        expect(received).toBe(NONE);
+            return rx.endMap();
+          }),
+        ).toBe(NONE);
       });
     });
 
     describe('putValue', () => {
       it('ignores value', () => {
-        rx.putValue('key', 'some', 'string');
+        expect(
+          chargeRx.rxMap(rx => {
+            rx.putValue('key', 'some', 'string');
 
-        expect(rx.endMap()).toBe(NONE);
-        expect(received).toBe(NONE);
+            return rx.endMap();
+          }),
+        ).toBe(NONE);
       });
     });
 
-    describe('startMap', () => {
+    describe('rxMap', () => {
       it('ignores charge', () => {
-        rx.startMap('key').endMap();
+        expect(
+          chargeRx.rxMap(rx => {
+            rx.rxMap('key', rx => rx.endMap());
 
-        expect(rx.endMap()).toBe(NONE);
-        expect(received).toBe(NONE);
+            return rx.endMap();
+          }),
+        ).toBe(NONE);
       });
     });
 
     describe('startList', () => {
       it('ignores charge', () => {
-        rx.startList('key').endList();
+        expect(
+          chargeRx.rxMap(rx => {
+            rx.startList('key').endList();
 
-        expect(rx.endMap()).toBe(NONE);
-        expect(received).toBe(NONE);
+            return rx.endMap();
+          }),
+        ).toBe(NONE);
       });
     });
 
     describe('startDirective', () => {
       it('ignores charge', () => {
-        rx.startDirective('key', '!test').endDirective();
+        expect(
+          chargeRx.rxMap(rx => {
+            rx.startDirective('key', '!test').endDirective();
 
-        expect(rx.endMap()).toBe(NONE);
-        expect(received).toBe(NONE);
+            return rx.endMap();
+          }),
+        ).toBe(NONE);
       });
     });
   });

--- a/src/charge/opaque-uri-charge-rx.spec.ts
+++ b/src/charge/opaque-uri-charge-rx.spec.ts
@@ -23,28 +23,16 @@ describe('OpaqueURIChargeRx', () => {
   });
 
   describe('ValueRx', () => {
-    let rx: URIChargeRx.ValueRx;
-    let received: unknown;
-
-    beforeEach(() => {
-      rx = chargeRx.rxValue(charge => {
-        received = charge;
-      });
-      received = undefined;
-    });
-
     describe('setValue', () => {
       it('charges none', () => {
-        expect(rx.setValue('some', 'string')).toBe(NONE);
-        expect(received).toBe(NONE);
+        expect(chargeRx.rxValue(rx => rx.setValue('some', 'string'))).toBe(NONE);
       });
     });
     describe('setCharge', () => {
       it('charges input', () => {
         const charge = { name: 'test charge' };
 
-        expect(rx.set(charge)).toBe(charge);
-        expect(received).toBe(charge);
+        expect(chargeRx.rxValue(rx => rx.set(charge))).toBe(charge);
       });
     });
   });

--- a/src/charge/opaque.uri-charge-rx.ts
+++ b/src/charge/opaque.uri-charge-rx.ts
@@ -32,19 +32,8 @@ export class OpaqueURIChargeRx<out TValue = ChURIPrimitive, out TCharge = unknow
       extends this.ItemsRx<TValue, TCharge, TRx>
       implements URIChargeRx.ListRx<TValue, TCharge, TRx> {
 
-      readonly #endList: URIChargeRx.End<TCharge> | undefined;
-
-      constructor(chargeRx: TRx, endList?: URIChargeRx.End<TCharge>) {
-        super(chargeRx);
-        this.#endList = endList;
-      }
-
       endList(): TCharge {
-        const { none } = this.chargeRx;
-
-        this.#endList?.(none);
-
-        return none;
+        return this.chargeRx.none;
       }
 
 }
@@ -66,12 +55,10 @@ export class OpaqueURIChargeRx<out TValue = ChURIPrimitive, out TCharge = unknow
       implements URIChargeRx.DirectiveRx<TValue, TCharge, TRx> {
 
       readonly #rawName: string;
-      readonly #endDirective: URIChargeRx.End<TCharge> | undefined;
 
-      constructor(chargeRx: TRx, rawName: string, endDirective?: URIChargeRx.End<TCharge>) {
+      constructor(chargeRx: TRx, rawName: string) {
         super(chargeRx);
         this.#rawName = rawName;
-        this.#endDirective = endDirective;
       }
 
       get rawName(): string {
@@ -79,11 +66,7 @@ export class OpaqueURIChargeRx<out TValue = ChURIPrimitive, out TCharge = unknow
       }
 
       endDirective(): TCharge {
-        const { none } = this.chargeRx;
-
-        this.#endDirective?.(none);
-
-        return none;
+        return this.chargeRx.none;
       }
 
 }

--- a/src/charge/opaque.uri-charge-rx.ts
+++ b/src/charge/opaque.uri-charge-rx.ts
@@ -121,15 +121,15 @@ export class OpaqueURIChargeRx<out TValue = ChURIPrimitive, out TCharge = unknow
     return parse(new this.ns.MapRx(this));
   }
 
-  rxList(endList?: URIChargeRx.End<TCharge>): URIChargeRx.ListRx<TValue, TCharge> {
-    return new this.ns.ListRx(this, endList);
+  rxList(parse: (rx: URIChargeRx.ListRx<TValue, TCharge>) => TCharge): TCharge {
+    return parse(new this.ns.ListRx(this));
   }
 
   rxDirective(
     rawName: string,
-    endDirective?: URIChargeRx.End<TCharge> | undefined,
-  ): URIChargeRx.DirectiveRx<TValue, TCharge> {
-    return new this.ns.DirectiveRx(this, rawName, endDirective);
+    parse: (rx: URIChargeRx.DirectiveRx<TValue, TCharge>) => TCharge,
+  ): TCharge {
+    return parse(new this.ns.DirectiveRx(this, rawName));
   }
 
 }
@@ -163,12 +163,15 @@ class OpaqueURICharge$ValueRx<out TValue, out TCharge, out TRx extends URICharge
     return this.chargeRx.rxMap(parse);
   }
 
-  startList(): URIChargeRx.ListRx<TValue, TCharge> {
-    return this.#chargeRx.rxList();
+  rxList(parse: (rx: URIChargeRx.ListRx<TValue, TCharge>) => TCharge): TCharge {
+    return this.chargeRx.rxList(parse);
   }
 
-  startDirective(rawName: string): URIChargeRx.DirectiveRx<TValue, TCharge> {
-    return this.#chargeRx.rxDirective(rawName);
+  rxDirective(
+    rawName: string,
+    parse: (rx: URIChargeRx.DirectiveRx<TValue, TCharge>) => TCharge,
+  ): TCharge {
+    return this.#chargeRx.rxDirective(rawName, parse);
   }
 
 }
@@ -198,25 +201,38 @@ class OpaqueURICharge$MapRx<out TValue, out TCharge, out TRx extends URIChargeRx
     this.put(key, this.#chargeRx.createValue(value, type));
   }
 
-  rxMap(
-    key: string,
-    parse: (rx: URIChargeRx.MapRx<TValue, unknown, URIChargeRx<TValue, unknown>>) => TCharge,
-  ): TCharge {
+  rxMap(key: string, parse: (rx: URIChargeRx.MapRx<TValue>) => TCharge): TCharge {
     return this.#chargeRx.rxMap(rx => {
-      const charge = parse(rx);
+      const map = parse(rx);
 
-      this.put(key, charge);
+      this.put(key, map);
 
-      return charge;
+      return map;
     });
   }
 
-  startList(key: string): URIChargeRx.ListRx<TValue> {
-    return this.#chargeRx.rxList(list => this.put(key, list));
+  rxList(key: string, parse: (rx: URIChargeRx.ListRx<TValue>) => TCharge): TCharge {
+    return this.#chargeRx.rxList(rx => {
+      const list = parse(rx);
+
+      this.put(key, list);
+
+      return list;
+    });
   }
 
-  startDirective(key: string, rawName: string): URIChargeRx.DirectiveRx<TValue> {
-    return this.#chargeRx.rxDirective(rawName, directive => this.put(key, directive));
+  rxDirective(
+    key: string,
+    rawName: string,
+    parse: (rx: URIChargeRx.DirectiveRx<TValue>) => TCharge,
+  ): TCharge {
+    return this.#chargeRx.rxDirective(rawName, rx => {
+      const directive = parse(rx);
+
+      this.put(key, directive);
+
+      return directive;
+    });
   }
 
   addSuffix(suffix: string): void {
@@ -269,12 +285,24 @@ abstract class OpaqueURICharge$ItemsRx<
     });
   }
 
-  startList(): URIChargeRx.ListRx<TValue> {
-    return this.#chargeRx.rxList(list => this.add(list));
+  rxList(parse: (rx: URIChargeRx.ListRx<TValue>) => TCharge): TCharge {
+    return this.#chargeRx.rxList(rx => {
+      const list = parse(rx);
+
+      this.add(list);
+
+      return list;
+    });
   }
 
-  startDirective(rawName: string): URIChargeRx.DirectiveRx<TValue> {
-    return this.#chargeRx.rxDirective(rawName, directive => this.add(directive));
+  rxDirective(rawName: string, parse: (rx: URIChargeRx.DirectiveRx<TValue>) => TCharge): TCharge {
+    return this.#chargeRx.rxDirective(rawName, rx => {
+      const directive = parse(rx);
+
+      this.add(directive);
+
+      return directive;
+    });
   }
 
 }

--- a/src/charge/opaque.uri-charge-rx.ts
+++ b/src/charge/opaque.uri-charge-rx.ts
@@ -184,8 +184,8 @@ class OpaqueURICharge$MapRx<out TValue, out TCharge, out TRx extends URIChargeRx
     this.put(key, this.#chargeRx.createValue(value, type));
   }
 
-  rxMap(key: string, parse: (rx: URIChargeRx.MapRx<TValue>) => TCharge): TCharge {
-    return this.#chargeRx.rxMap(rx => {
+  rxMap(key: string, parse: (rx: URIChargeRx.MapRx<TValue, TCharge>) => TCharge): void {
+    this.#chargeRx.rxMap(rx => {
       const map = parse(rx);
 
       this.put(key, map);
@@ -194,8 +194,8 @@ class OpaqueURICharge$MapRx<out TValue, out TCharge, out TRx extends URIChargeRx
     });
   }
 
-  rxList(key: string, parse: (rx: URIChargeRx.ListRx<TValue>) => TCharge): TCharge {
-    return this.#chargeRx.rxList(rx => {
+  rxList(key: string, parse: (rx: URIChargeRx.ListRx<TValue, TCharge>) => TCharge): void {
+    this.#chargeRx.rxList(rx => {
       const list = parse(rx);
 
       this.put(key, list);
@@ -207,9 +207,9 @@ class OpaqueURICharge$MapRx<out TValue, out TCharge, out TRx extends URIChargeRx
   rxDirective(
     key: string,
     rawName: string,
-    parse: (rx: URIChargeRx.DirectiveRx<TValue>) => TCharge,
-  ): TCharge {
-    return this.#chargeRx.rxDirective(rawName, rx => {
+    parse: (rx: URIChargeRx.DirectiveRx<TValue, TCharge>) => TCharge,
+  ): void {
+    this.#chargeRx.rxDirective(rawName, rx => {
       const directive = parse(rx);
 
       this.put(key, directive);
@@ -256,10 +256,8 @@ abstract class OpaqueURICharge$ItemsRx<
     this.add(this.#chargeRx.createValue(value, type));
   }
 
-  rxMap(
-    parse: (rx: URIChargeRx.MapRx<TValue, unknown, URIChargeRx<TValue, unknown>>) => TCharge,
-  ): TCharge {
-    return this.#chargeRx.rxMap(rx => {
+  rxMap(parse: (rx: URIChargeRx.MapRx<TValue, TCharge>) => TCharge): void {
+    this.#chargeRx.rxMap(rx => {
       const charge = parse(rx);
 
       this.add(charge);
@@ -268,8 +266,8 @@ abstract class OpaqueURICharge$ItemsRx<
     });
   }
 
-  rxList(parse: (rx: URIChargeRx.ListRx<TValue>) => TCharge): TCharge {
-    return this.#chargeRx.rxList(rx => {
+  rxList(parse: (rx: URIChargeRx.ListRx<TValue, TCharge>) => TCharge): void {
+    this.#chargeRx.rxList(rx => {
       const list = parse(rx);
 
       this.add(list);
@@ -278,8 +276,11 @@ abstract class OpaqueURICharge$ItemsRx<
     });
   }
 
-  rxDirective(rawName: string, parse: (rx: URIChargeRx.DirectiveRx<TValue>) => TCharge): TCharge {
-    return this.#chargeRx.rxDirective(rawName, rx => {
+  rxDirective(
+    rawName: string,
+    parse: (rx: URIChargeRx.DirectiveRx<TValue, TCharge>) => TCharge,
+  ): void {
+    this.#chargeRx.rxDirective(rawName, rx => {
       const directive = parse(rx);
 
       this.add(directive);

--- a/src/charge/opaque.uri-charge-rx.ts
+++ b/src/charge/opaque.uri-charge-rx.ts
@@ -113,8 +113,8 @@ export class OpaqueURIChargeRx<out TValue = ChURIPrimitive, out TCharge = unknow
     return this.none;
   }
 
-  rxValue(endValue?: URIChargeRx.End<TCharge>): URIChargeRx.ValueRx<TValue, TCharge> {
-    return new this.ns.ValueRx(this, endValue);
+  rxValue<T>(parse: (rx: URIChargeRx.ValueRx<TValue, TCharge>) => T): T {
+    return parse(new this.ns.ValueRx(this));
   }
 
   rxMap(endMap?: URIChargeRx.End<TCharge>): URIChargeRx.MapRx<TValue, TCharge> {
@@ -138,11 +138,9 @@ class OpaqueURICharge$ValueRx<out TValue, out TCharge, out TRx extends URICharge
   implements URIChargeRx.ValueRx<TValue, TCharge, TRx> {
 
   readonly #chargeRx: TRx;
-  readonly #passCharge: <TResult extends TCharge>(this: void, charge: TResult) => TCharge;
 
-  constructor(chargeRx: TRx, endCharge?: URIChargeRx.End<TCharge>) {
+  constructor(chargeRx: TRx) {
     this.#chargeRx = chargeRx;
-    this.#passCharge = endCharge ? charge => (endCharge(charge), charge) : charge => charge;
   }
 
   get chargeRx(): TRx {
@@ -150,7 +148,7 @@ class OpaqueURICharge$ValueRx<out TValue, out TCharge, out TRx extends URICharge
   }
 
   set(charge: TCharge): TCharge {
-    return this.#passCharge(charge);
+    return charge;
   }
 
   setEntity(rawEntity: string): TCharge {
@@ -162,15 +160,15 @@ class OpaqueURICharge$ValueRx<out TValue, out TCharge, out TRx extends URICharge
   }
 
   startMap(): URIChargeRx.MapRx<TValue, TCharge> {
-    return this.#chargeRx.rxMap(this.#passCharge);
+    return this.#chargeRx.rxMap();
   }
 
   startList(): URIChargeRx.ListRx<TValue, TCharge> {
-    return this.#chargeRx.rxList(this.#passCharge);
+    return this.#chargeRx.rxList();
   }
 
   startDirective(rawName: string): URIChargeRx.DirectiveRx<TValue, TCharge> {
-    return this.#chargeRx.rxDirective(rawName, this.#passCharge);
+    return this.#chargeRx.rxDirective(rawName);
   }
 
 }

--- a/src/charge/parse-ch-uri-value.spec.ts
+++ b/src/charge/parse-ch-uri-value.spec.ts
@@ -284,6 +284,9 @@ describe('parseChURIValue', () => {
   });
 
   describe('map suffix', () => {
+    it('parsed for top-level map', () => {
+      expect(parse('foo(456)suffix').charge).toEqual({ foo: 456, suffix: '' });
+    });
     it('treated as trailing map-valued item of top-level list', () => {
       expect(parse('(123)(456)foo').charge).toEqual([123, 456, { foo: '' }]);
     });
@@ -329,9 +332,9 @@ describe('parseChURIValue', () => {
     });
     it('recognized without parameters', () => {
       const builder = new ChURIValueBuilder();
-      const { rawName, value } = builder.rxDirective('test').endDirective() as ChURIDirective;
+      const { rawName, value } = builder.rxDirective('!test', rx => rx.endDirective()) as ChURIDirective;
 
-      expect(rawName).toBe('test');
+      expect(rawName).toBe('!test');
       expect(value).toBe(builder.none);
     });
   });

--- a/src/charge/parse-uri-charge.spec.ts
+++ b/src/charge/parse-uri-charge.spec.ts
@@ -296,9 +296,9 @@ describe('parseURICharge', () => {
       });
     });
     it('recognized without parameters', () => {
-      const charge = new URIChargeBuilder().rxDirective('test').endDirective();
+      const charge = new URIChargeBuilder().rxDirective('!test', rx => rx.endDirective());
 
-      expect(charge).toHaveURIChargeValue({ rawName: 'test', value: undefined });
+      expect(charge).toHaveURIChargeValue({ rawName: '!test', value: undefined });
     });
   });
 

--- a/src/charge/uri-charge-builder.ts
+++ b/src/charge/uri-charge-builder.ts
@@ -155,11 +155,11 @@ class URIChargeBuilder$MapRx<out TValue, out TRx extends URIChargeBuilder<TValue
 
   override rxMap(
     key: string,
-    parse: (rx: URIChargeRx.MapRx<URIChargeItem<TValue>>) => URICharge<TValue>,
-  ): URICharge<TValue> {
+    parse: (rx: URIChargeBuilder.MapRx<TValue>) => URICharge<TValue>,
+  ): void {
     const prevCharge = this.#map.get(key);
 
-    return this.chargeRx.rxMap(
+    this.chargeRx.rxMap(
       rx => {
         const map = parse(rx);
 
@@ -174,11 +174,11 @@ class URIChargeBuilder$MapRx<out TValue, out TRx extends URIChargeBuilder<TValue
 
   override rxList(
     key: string,
-    parse: (rx: URIChargeRx.ListRx<URIChargeItem<TValue>>) => URICharge<TValue>,
-  ): URICharge<TValue> {
+    parse: (rx: URIChargeBuilder.ListRx<TValue>) => URICharge<TValue>,
+  ): void {
     const prevCharge = this.#map.get(key);
 
-    return this.chargeRx.rxList(rx => {
+    this.chargeRx.rxList(rx => {
       const list = parse(rx);
 
       this.put(key, list);

--- a/src/charge/uri-charge-builder.ts
+++ b/src/charge/uri-charge-builder.ts
@@ -140,7 +140,6 @@ class URIChargeBuilder$MapRx<out TValue, out TRx extends URIChargeBuilder<TValue
   extends OpaqueMapRx<URIChargeItem<TValue>, URICharge<TValue>, TRx>
   implements URIChargeBuilder.MapRx<TValue, TRx> {
 
-  readonly #endMap?: URIChargeRx.End<URICharge.Map<TValue>>;
   readonly #map: Map<string, URICharge.Some<TValue>>;
 
   constructor(chargeRx: TRx, base?: URICharge.Map<TValue>) {
@@ -189,11 +188,7 @@ class URIChargeBuilder$MapRx<out TValue, out TRx extends URIChargeBuilder<TValue
   }
 
   override endMap(): URICharge.Map<TValue> {
-    const map = new URICharge$Map(this.#map);
-
-    this.#endMap?.(map);
-
-    return map;
+    return new URICharge$Map(this.#map);
   }
 
 }

--- a/src/charge/uri-charge-builder.ts
+++ b/src/charge/uri-charge-builder.ts
@@ -39,8 +39,8 @@ export class URIChargeBuilder<out TValue = ChURIPrimitive>
     return new URICharge$Single(value, type);
   }
 
-  rxValue(endValue?: URIChargeRx.End<URICharge<TValue>>): URIChargeBuilder.ValueRx<TValue> {
-    return new this.ns.ValueRx(this, endValue);
+  rxValue<T>(parse: (rx: URIChargeRx.ValueRx<URIChargeItem<TValue>, URICharge<TValue>>) => T): T {
+    return parse(new this.ns.ValueRx(this));
   }
 
   rxMap(
@@ -85,7 +85,6 @@ export namespace URIChargeBuilder {
       TRx extends URIChargeBuilder<TValue> = URIChargeBuilder<TValue>,
     >(
       chargeRx: TRx,
-      endValue?: URIChargeRx.End<URICharge<TValue>>,
     ) => ValueRx<TValue, TRx>;
   }
 

--- a/src/charge/uri-charge-codec.spec.ts
+++ b/src/charge/uri-charge-codec.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 import { ChURIDirective, ChURIEntity } from './ch-uri-value.js';
-import { encodeURICharge } from './encode-uri-charge.js';
 import { parseURICharge } from './parse-uri-charge.js';
+import { encodeURICharge } from './uri-charge-codec.js';
 import { URIChargeEncodable } from './uri-charge-encodable.js';
 import { URICharge } from './uri-charge.js';
 

--- a/src/charge/uri-charge-codec.ts
+++ b/src/charge/uri-charge-codec.ts
@@ -57,6 +57,17 @@ export function encodeURIChargeKey(key: string, placement?: URIChargeEncodable.P
 }
 
 /**
+ * Decodes key of URI charge map entry.
+ *
+ * @param encoded - Percent-encoded and possibly escaped key.
+ *
+ * @returns Decoded key.
+ */
+export function decodeURIChargeKey(encoded: string): string {
+  return decodeURIComponent(encoded.startsWith("'") ? encoded.slice(1) : encoded);
+}
+
+/**
  * Encodes URI charge string value.
  *
  * @param key - Entry key to encode.

--- a/src/charge/uri-charge-ext.spec.ts
+++ b/src/charge/uri-charge-ext.spec.ts
@@ -17,12 +17,12 @@ describe('URIChargeExt', () => {
           ChURIValue<ChURIPrimitive | TestValue>
         > => ({
           entities: {
-            ['!test']({
-              rx,
-            }: URIChargeExt.Context<
-              ChURIPrimitive | TestValue,
-              ChURIValue<ChURIPrimitive | TestValue>
-            >): ChURIValue<ChURIPrimitive | TestValue> {
+            ['!test'](
+              rx: URIChargeRx.ValueRx<
+                ChURIPrimitive | TestValue,
+                ChURIValue<ChURIPrimitive | TestValue>
+              >,
+            ): ChURIValue<ChURIPrimitive | TestValue> {
               return rx.set({ [test__symbol]: 'test value' });
             },
           },
@@ -58,7 +58,7 @@ describe('URIChargeExt', () => {
         > => ({
           directives: {
             ['!test'](
-              { rx },
+              rx,
               rawName: string,
               parse: (
                 rx: URIChargeRx.DirectiveRx<

--- a/src/charge/uri-charge-ext.spec.ts
+++ b/src/charge/uri-charge-ext.spec.ts
@@ -17,13 +17,8 @@ describe('URIChargeExt', () => {
           ChURIValue<ChURIPrimitive | TestValue>
         > => ({
           entities: {
-            ['!test'](
-              rx: URIChargeRx.ValueRx<
-                ChURIPrimitive | TestValue,
-                ChURIValue<ChURIPrimitive | TestValue>
-              >,
-            ): ChURIValue<ChURIPrimitive | TestValue> {
-              return rx.set({ [test__symbol]: 'test value' });
+            ['!test'](): ChURIValue<ChURIPrimitive | TestValue> {
+              return { [test__symbol]: 'test value' };
             },
           },
         }),
@@ -52,13 +47,11 @@ describe('URIChargeExt', () => {
 
     beforeAll(() => {
       parser = createChURIValueParser({
-        ext: (): URIChargeExt<
-          ChURIPrimitive | TestValue,
-          ChURIValue<ChURIPrimitive | TestValue>
-        > => ({
+        ext: (
+          charge,
+        ): URIChargeExt<ChURIPrimitive | TestValue, ChURIValue<ChURIPrimitive | TestValue>> => ({
           directives: {
             ['!test'](
-              rx,
               rawName: string,
               parse: (
                 rx: URIChargeRx.DirectiveRx<
@@ -67,7 +60,7 @@ describe('URIChargeExt', () => {
                 >,
               ) => ChURIValue<ChURIPrimitive | TestValue>,
             ): ChURIValue<ChURIPrimitive | TestValue> {
-              return parse(new TestDirectiveRx(rx, rawName));
+              return charge.rxValue(rx => parse(new TestDirectiveRx(rx, rawName)));
             },
           },
         }),

--- a/src/charge/uri-charge-ext.spec.ts
+++ b/src/charge/uri-charge-ext.spec.ts
@@ -60,11 +60,14 @@ describe('URIChargeExt', () => {
             ['!test'](
               { rx },
               rawName: string,
-            ): URIChargeRx.DirectiveRx<
-              ChURIPrimitive | TestValue,
-              ChURIValue<ChURIPrimitive | TestValue>
-            > {
-              return new TestDirectiveRx(rx, rawName);
+              parse: (
+                rx: URIChargeRx.DirectiveRx<
+                  ChURIPrimitive | TestValue,
+                  ChURIValue<ChURIPrimitive | TestValue>
+                >,
+              ) => ChURIValue<ChURIPrimitive | TestValue>,
+            ): ChURIValue<ChURIPrimitive | TestValue> {
+              return parse(new TestDirectiveRx(rx, rawName));
             },
           },
         }),

--- a/src/charge/uri-charge-ext.ts
+++ b/src/charge/uri-charge-ext.ts
@@ -59,6 +59,7 @@ export namespace URIChargeExt {
     rxDirective(
       context: Context<TValue, TCharge>,
       rawName: string,
-    ): URIChargeRx.DirectiveRx<TValue, TCharge>;
+      parse: (rx: URIChargeRx.DirectiveRx<TValue, TCharge>) => TCharge,
+    ): TCharge;
   }['rxDirective'];
 }

--- a/src/charge/uri-charge-ext.ts
+++ b/src/charge/uri-charge-ext.ts
@@ -4,7 +4,7 @@ import { URIChargeRx } from './uri-charge-rx.js';
 export interface URIChargeExt<out TValue = unknown, out TCharge = unknown> {
   readonly entities?:
     | {
-        readonly [rawEntity: string]: URIChargeExt.EntityHandler<TValue, TCharge>;
+        readonly [rawEntity: string]: URIChargeExt.EntityHandler<TCharge>;
       }
     | undefined;
   readonly directives?:
@@ -17,11 +17,9 @@ export interface URIChargeExt<out TValue = unknown, out TCharge = unknown> {
 export function URIChargeExt<TValue, TCharge>(
   spec: URIChargeExt.Spec<TValue, TCharge>,
 ): URIChargeExt.Factory<TValue, TCharge> {
-  return <TVal extends TValue, TCh extends TCharge>(
-    chargeRx: URIChargeRx<TVal, TCh>,
-  ): URIChargeExt<TVal, TCh> => {
-    const entities: Record<string, URIChargeExt.EntityHandler<TVal, TCh>> = {};
-    const directives: Record<string, URIChargeExt.DirectiveHandler<TVal, TCh>> = {};
+  return (chargeRx: URIChargeRx<TValue, TCharge>): URIChargeExt<TValue, TCharge> => {
+    const entities: Record<string, URIChargeExt.EntityHandler<TCharge>> = {};
+    const directives: Record<string, URIChargeExt.DirectiveHandler<TValue, TCharge>> = {};
 
     for (const factory of asArray(spec)) {
       const ext = factory(chargeRx);
@@ -47,13 +45,12 @@ export namespace URIChargeExt {
     extendCharge(chargeRx: URIChargeRx<TValue, TCharge>): URIChargeExt<TValue, TCharge>;
   }['extendCharge'];
 
-  export type EntityHandler<out TValue = unknown, out TCharge = unknown> = {
-    createEntity(rx: URIChargeRx.ValueRx<TValue, TCharge>, rawEntity: string): TCharge;
+  export type EntityHandler<out TCharge = unknown> = {
+    createEntity(rawEntity: string): TCharge;
   }['createEntity'];
 
   export type DirectiveHandler<out TValue = unknown, out TCharge = unknown> = {
     rxDirective(
-      rx: URIChargeRx.ValueRx<TValue, TCharge>,
       rawName: string,
       parse: (rx: URIChargeRx.DirectiveRx<TValue, TCharge>) => TCharge,
     ): TCharge;

--- a/src/charge/uri-charge-ext.ts
+++ b/src/charge/uri-charge-ext.ts
@@ -47,17 +47,13 @@ export namespace URIChargeExt {
     extendCharge(chargeRx: URIChargeRx<TValue, TCharge>): URIChargeExt<TValue, TCharge>;
   }['extendCharge'];
 
-  export interface Context<out TValue = unknown, out TCharge = unknown> {
-    readonly rx: URIChargeRx.ValueRx<TValue, TCharge>;
-  }
-
   export type EntityHandler<out TValue = unknown, out TCharge = unknown> = {
-    createEntity(context: Context<TValue, TCharge>, rawEntity: string): TCharge;
+    createEntity(rx: URIChargeRx.ValueRx<TValue, TCharge>, rawEntity: string): TCharge;
   }['createEntity'];
 
   export type DirectiveHandler<out TValue = unknown, out TCharge = unknown> = {
     rxDirective(
-      context: Context<TValue, TCharge>,
+      rx: URIChargeRx.ValueRx<TValue, TCharge>,
       rawName: string,
       parse: (rx: URIChargeRx.DirectiveRx<TValue, TCharge>) => TCharge,
     ): TCharge;

--- a/src/charge/uri-charge-parser.ts
+++ b/src/charge/uri-charge-parser.ts
@@ -2,7 +2,7 @@ import { ChURIPrimitive } from './ch-uri-value.js';
 import { decodeChURIValue } from './impl/ch-uri-value-decoder.js';
 import { parseChURIValue } from './impl/parse-ch-uri-value.js';
 import { URIChargeExtParser } from './impl/uri-charge-ext-parser.js';
-import { URIChargeTarget } from './impl/uri-charge-target.js';
+import { ChURIValueTarget } from './impl/uri-charge-target.js';
 import { URIChargeExt } from './uri-charge-ext.js';
 import { URIChargeRx } from './uri-charge-rx.js';
 
@@ -39,12 +39,7 @@ export class URIChargeParser<out TValue = ChURIPrimitive, out TCharge = unknown>
   }
 
   #parse(input: string, rx: URIChargeRx.ValueRx<TValue, TCharge>): URIChargeParser.Result<TCharge> {
-    const to: URIChargeTarget<TValue, TCharge> = {
-      rx,
-      ext: this.#extParser,
-    };
-
-    return parseChURIValue(to, decodeChURIValue, input);
+    return parseChURIValue(new ChURIValueTarget(rx, this.#extParser), decodeChURIValue, input);
   }
 
 }

--- a/src/charge/uri-charge-parser.ts
+++ b/src/charge/uri-charge-parser.ts
@@ -22,10 +22,11 @@ export class URIChargeParser<out TValue = ChURIPrimitive, out TCharge = unknown>
     return this.#rx;
   }
 
-  parse(
-    input: string,
-    rx: URIChargeRx.ValueRx<TValue, TCharge> = this.chargeRx.rxValue(),
-  ): URIChargeParser.Result<TCharge> {
+  parse(input: string, rx?: URIChargeRx.ValueRx<TValue, TCharge>): URIChargeParser.Result<TCharge> {
+    return rx ? this.#parse(input, rx) : this.chargeRx.rxValue(rx => this.#parse(input, rx));
+  }
+
+  #parse(input: string, rx: URIChargeRx.ValueRx<TValue, TCharge>): URIChargeParser.Result<TCharge> {
     const decoder = defaultChURIValueDecoder;
 
     const to: URIChargeTarget<TValue, TCharge> = {

--- a/src/charge/uri-charge-parser.ts
+++ b/src/charge/uri-charge-parser.ts
@@ -41,11 +41,10 @@ export class URIChargeParser<out TValue = ChURIPrimitive, out TCharge = unknown>
   #parse(input: string, rx: URIChargeRx.ValueRx<TValue, TCharge>): URIChargeParser.Result<TCharge> {
     const to: URIChargeTarget<TValue, TCharge> = {
       rx,
-      decoder: decodeChURIValue,
       ext: this.#extParser,
     };
 
-    return parseChURIValue(to, input);
+    return parseChURIValue(to, decodeChURIValue, input);
   }
 
 }

--- a/src/charge/uri-charge-parser.ts
+++ b/src/charge/uri-charge-parser.ts
@@ -45,7 +45,6 @@ export class URIChargeParser<out TValue = ChURIPrimitive, out TCharge = unknown>
       rx,
       decoder,
       ext: this.#extParser,
-      decode: input => decoder.decodeValue(to, input),
     };
 
     return parseChURIValue(to, input);

--- a/src/charge/uri-charge-parser.ts
+++ b/src/charge/uri-charge-parser.ts
@@ -1,5 +1,5 @@
 import { ChURIPrimitive } from './ch-uri-value.js';
-import { defaultChURIValueDecoder } from './impl/ch-uri-value-decoder.js';
+import { decodeChURIValue } from './impl/ch-uri-value-decoder.js';
 import { parseChURIValue } from './impl/parse-ch-uri-value.js';
 import { URIChargeExtParser } from './impl/uri-charge-ext-parser.js';
 import { URIChargeTarget } from './impl/uri-charge-target.js';
@@ -39,11 +39,9 @@ export class URIChargeParser<out TValue = ChURIPrimitive, out TCharge = unknown>
   }
 
   #parse(input: string, rx: URIChargeRx.ValueRx<TValue, TCharge>): URIChargeParser.Result<TCharge> {
-    const decoder = defaultChURIValueDecoder;
-
     const to: URIChargeTarget<TValue, TCharge> = {
       rx,
-      decoder,
+      decoder: decodeChURIValue,
       ext: this.#extParser,
     };
 

--- a/src/charge/uri-charge-parser.ts
+++ b/src/charge/uri-charge-parser.ts
@@ -23,7 +23,19 @@ export class URIChargeParser<out TValue = ChURIPrimitive, out TCharge = unknown>
   }
 
   parse(input: string, rx?: URIChargeRx.ValueRx<TValue, TCharge>): URIChargeParser.Result<TCharge> {
-    return rx ? this.#parse(input, rx) : this.chargeRx.rxValue(rx => this.#parse(input, rx));
+    if (rx) {
+      return this.#parse(input, rx);
+    }
+
+    let result!: URIChargeParser.Result<TCharge>;
+
+    this.chargeRx.rxValue(rx => {
+      result = this.#parse(input, rx);
+
+      return result.charge;
+    });
+
+    return result;
   }
 
   #parse(input: string, rx: URIChargeRx.ValueRx<TValue, TCharge>): URIChargeParser.Result<TCharge> {

--- a/src/charge/uri-charge-parser.ts
+++ b/src/charge/uri-charge-parser.ts
@@ -2,20 +2,19 @@ import { ChURIPrimitive } from './ch-uri-value.js';
 import { decodeChURIValue } from './impl/ch-uri-value-decoder.js';
 import { parseChURIValue } from './impl/parse-ch-uri-value.js';
 import { URIChargeExtParser } from './impl/uri-charge-ext-parser.js';
-import { ChURIValueTarget } from './impl/uri-charge-target.js';
 import { URIChargeExt } from './uri-charge-ext.js';
 import { URIChargeRx } from './uri-charge-rx.js';
 
 export class URIChargeParser<out TValue = ChURIPrimitive, out TCharge = unknown> {
 
   readonly #rx: URIChargeRx<TValue, TCharge>;
-  readonly #extParser: URIChargeExtParser<TValue, TCharge>;
+  readonly #ext: URIChargeExtParser<TValue, TCharge>;
 
   constructor(options: URIChargeParser.Options<TValue, TCharge>) {
     const { rx, ext } = options;
 
     this.#rx = rx;
-    this.#extParser = new URIChargeExtParser(rx, ext);
+    this.#ext = new URIChargeExtParser(rx, ext);
   }
 
   get chargeRx(): URIChargeRx<TValue, TCharge> {
@@ -39,7 +38,7 @@ export class URIChargeParser<out TValue = ChURIPrimitive, out TCharge = unknown>
   }
 
   #parse(input: string, rx: URIChargeRx.ValueRx<TValue, TCharge>): URIChargeParser.Result<TCharge> {
-    return parseChURIValue(new ChURIValueTarget(rx, this.#extParser), decodeChURIValue, input);
+    return parseChURIValue(this.#ext.valueTarget, rx, '', decodeChURIValue, input);
   }
 
 }

--- a/src/charge/uri-charge-rx.ts
+++ b/src/charge/uri-charge-rx.ts
@@ -82,15 +82,15 @@ export namespace URIChargeRx {
 
     putValue(key: string, value: ChURIPrimitive | TValue, type: string): void;
 
-    rxMap(key: string, parse: (rx: URIChargeRx.MapRx<TValue>) => TCharge): TCharge;
+    rxMap(key: string, parse: (rx: URIChargeRx.MapRx<TValue, TCharge>) => TCharge): void;
 
-    rxList(key: string, parse: (rx: URIChargeRx.ListRx<TValue>) => TCharge): TCharge;
+    rxList(key: string, parse: (rx: URIChargeRx.ListRx<TValue, TCharge>) => TCharge): void;
 
     rxDirective(
       key: string,
       rawName: string,
-      parse: (rx: URIChargeRx.DirectiveRx<TValue>) => TCharge,
-    ): TCharge;
+      parse: (rx: URIChargeRx.DirectiveRx<TValue, TCharge>) => TCharge,
+    ): void;
 
     addSuffix(suffix: string): void;
 
@@ -120,11 +120,14 @@ export namespace URIChargeRx {
 
     addValue(value: ChURIPrimitive | TValue, type: string): void;
 
-    rxMap(parse: (rx: URIChargeRx.MapRx<TValue>) => TCharge): TCharge;
+    rxMap(parse: (rx: URIChargeRx.MapRx<TValue, TCharge>) => TCharge): void;
 
-    rxList(parse: (rx: URIChargeRx.ListRx<TValue>) => TCharge): TCharge;
+    rxList(parse: (rx: URIChargeRx.ListRx<TValue, TCharge>) => TCharge): void;
 
-    rxDirective(rawName: string, parse: (rx: URIChargeRx.DirectiveRx<TValue>) => TCharge): TCharge;
+    rxDirective(
+      rawName: string,
+      parse: (rx: URIChargeRx.DirectiveRx<TValue, TCharge>) => TCharge,
+    ): void;
   }
 
   export namespace ItemsRx {

--- a/src/charge/uri-charge-rx.ts
+++ b/src/charge/uri-charge-rx.ts
@@ -32,10 +32,6 @@ export namespace URIChargeRx {
     readonly none: TCharge;
   }
 
-  export type End<out TCharge> = {
-    endCharge(this: void, charge: TCharge): void;
-  }['endCharge'];
-
   export type Parser<TRx, TCharge> = {
     parse(this: void, rx: TRx): TCharge;
   }['parse'];

--- a/src/charge/uri-charge-rx.ts
+++ b/src/charge/uri-charge-rx.ts
@@ -7,9 +7,9 @@ export interface URIChargeRx<out TValue = ChURIPrimitive, out TCharge = unknown>
 
   createValue(value: TValue | ChURIPrimitive, type: string): TCharge;
 
-  rxValue<T>(parse: (rx: URIChargeRx.ValueRx<TValue, TCharge>) => T): T;
+  rxValue(parse: (rx: URIChargeRx.ValueRx<TValue, TCharge>) => TCharge): TCharge;
 
-  rxMap(endMap?: URIChargeRx.End<TCharge>): URIChargeRx.MapRx<TValue, TCharge>;
+  rxMap(parse: (rx: URIChargeRx.MapRx<TValue, TCharge>) => TCharge): TCharge;
 
   rxList(endList?: URIChargeRx.End<TCharge>): URIChargeRx.ListRx<TValue, TCharge>;
 
@@ -53,7 +53,7 @@ export namespace URIChargeRx {
 
     setValue(value: ChURIPrimitive | TValue, type: string): TCharge;
 
-    startMap(): MapRx<TValue, TCharge>;
+    rxMap(parse: (rx: URIChargeRx.MapRx<TValue, TCharge>) => TCharge): TCharge;
 
     startList(): ListRx<TValue, TCharge>;
 
@@ -83,7 +83,7 @@ export namespace URIChargeRx {
 
     putValue(key: string, value: ChURIPrimitive | TValue, type: string): void;
 
-    startMap(key: string): MapRx<TValue>;
+    rxMap(key: string, parse: (rx: URIChargeRx.MapRx<TValue>) => TCharge): TCharge;
 
     startList(key: string): ListRx<TValue>;
 
@@ -101,7 +101,6 @@ export namespace URIChargeRx {
       TRx extends URIChargeRx<TValue, TCharge> = URIChargeRx<TValue, TCharge>,
     >(
       chargeRx: TRx,
-      endMap?: End<TCharge>,
     ) => MapRx<TValue, TCharge, TRx>;
   }
 
@@ -118,7 +117,7 @@ export namespace URIChargeRx {
 
     addValue(value: ChURIPrimitive | TValue, type: string): void;
 
-    startMap(): MapRx<TValue>;
+    rxMap(parse: (rx: URIChargeRx.MapRx<TValue>) => TCharge): TCharge;
 
     startList(): ListRx<TValue>;
 

--- a/src/charge/uri-charge-rx.ts
+++ b/src/charge/uri-charge-rx.ts
@@ -11,12 +11,12 @@ export interface URIChargeRx<out TValue = ChURIPrimitive, out TCharge = unknown>
 
   rxMap(parse: (rx: URIChargeRx.MapRx<TValue, TCharge>) => TCharge): TCharge;
 
-  rxList(endList?: URIChargeRx.End<TCharge>): URIChargeRx.ListRx<TValue, TCharge>;
+  rxList(parse: (rx: URIChargeRx.ListRx<TValue, TCharge>) => TCharge): TCharge;
 
   rxDirective(
     rawName: string,
-    endDirective?: URIChargeRx.End<TCharge> | undefined,
-  ): URIChargeRx.DirectiveRx<TValue, TCharge>;
+    parse: (rx: URIChargeRx.DirectiveRx<TValue, TCharge>) => TCharge,
+  ): TCharge;
 }
 
 export namespace URIChargeRx {
@@ -55,9 +55,12 @@ export namespace URIChargeRx {
 
     rxMap(parse: (rx: URIChargeRx.MapRx<TValue, TCharge>) => TCharge): TCharge;
 
-    startList(): ListRx<TValue, TCharge>;
+    rxList(parse: (rx: URIChargeRx.ListRx<TValue, TCharge>) => TCharge): TCharge;
 
-    startDirective(rawName: string): DirectiveRx<TValue, TCharge>;
+    rxDirective(
+      rawName: string,
+      parse: (rx: URIChargeRx.DirectiveRx<TValue, TCharge>) => TCharge,
+    ): TCharge;
   }
 
   export namespace ValueRx {
@@ -85,9 +88,13 @@ export namespace URIChargeRx {
 
     rxMap(key: string, parse: (rx: URIChargeRx.MapRx<TValue>) => TCharge): TCharge;
 
-    startList(key: string): ListRx<TValue>;
+    rxList(key: string, parse: (rx: URIChargeRx.ListRx<TValue>) => TCharge): TCharge;
 
-    startDirective(key: string, rawName: string): DirectiveRx<TValue>;
+    rxDirective(
+      key: string,
+      rawName: string,
+      parse: (rx: URIChargeRx.DirectiveRx<TValue>) => TCharge,
+    ): TCharge;
 
     addSuffix(suffix: string): void;
 
@@ -119,9 +126,9 @@ export namespace URIChargeRx {
 
     rxMap(parse: (rx: URIChargeRx.MapRx<TValue>) => TCharge): TCharge;
 
-    startList(): ListRx<TValue>;
+    rxList(parse: (rx: URIChargeRx.ListRx<TValue>) => TCharge): TCharge;
 
-    startDirective(rawName: string): DirectiveRx<TValue>;
+    rxDirective(rawName: string, parse: (rx: URIChargeRx.DirectiveRx<TValue>) => TCharge): TCharge;
   }
 
   export namespace ItemsRx {
@@ -131,7 +138,6 @@ export namespace URIChargeRx {
       TRx extends URIChargeRx<TValue, TCharge> = URIChargeRx<TValue, TCharge>,
     >(
       chargeRx: TRx,
-      endItems?: End<TCharge>,
     ) => ItemsRx<TValue, TCharge, TRx>;
   }
 
@@ -150,7 +156,6 @@ export namespace URIChargeRx {
       TRx extends URIChargeRx<TValue, TCharge> = URIChargeRx<TValue, TCharge>,
     >(
       chargeRx: TRx,
-      endList?: End<TCharge>,
     ) => ListRx<TValue, TCharge, TRx>;
   }
 
@@ -172,7 +177,6 @@ export namespace URIChargeRx {
     >(
       chargeRx: TRx,
       rawName: string,
-      endDirective?: End<TCharge>,
     ) => DirectiveRx<TValue, TCharge, TRx>;
   }
 }

--- a/src/charge/uri-charge-rx.ts
+++ b/src/charge/uri-charge-rx.ts
@@ -7,7 +7,7 @@ export interface URIChargeRx<out TValue = ChURIPrimitive, out TCharge = unknown>
 
   createValue(value: TValue | ChURIPrimitive, type: string): TCharge;
 
-  rxValue(endValue?: URIChargeRx.End<TCharge>): URIChargeRx.ValueRx<TValue, TCharge>;
+  rxValue<T>(parse: (rx: URIChargeRx.ValueRx<TValue, TCharge>) => T): T;
 
   rxMap(endMap?: URIChargeRx.End<TCharge>): URIChargeRx.MapRx<TValue, TCharge>;
 
@@ -36,6 +36,10 @@ export namespace URIChargeRx {
     endCharge(this: void, charge: TCharge): void;
   }['endCharge'];
 
+  export type Parser<TRx, TCharge> = {
+    parse(this: void, rx: TRx): TCharge;
+  }['parse'];
+
   export interface ValueRx<
     out TValue = ChURIPrimitive,
     out TCharge = unknown,
@@ -63,7 +67,6 @@ export namespace URIChargeRx {
       TRx extends URIChargeRx<TValue, TCharge> = URIChargeRx<TValue, TCharge>,
     >(
       chargeRx: TRx,
-      endValue?: End<TCharge>,
     ) => ValueRx<TValue, TCharge, TRx>;
   }
 


### PR DESCRIPTION
- Reactive `ValueRx` API
- Make `MapRx` reactive
- Make `ListRx` and `DirectiveRx` reactive
- Drop redundant interface
- Simplify rx interfaces
- Drop redundant method
- Simplify rx extensions API
- Always decode entry keys
- Export `decodeURIChargeKey()`
- Simplify value decoder API
- Dedicated directive args decoder
- Rename map entry target
-  `URIChargeTarget` handles entities and directives
- Construct charge target at most once
- Simplify extensions API
