### PR TITLE
Comma-separated lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ const { route, searchParams: query } = new ChURI(
 console.debug(route.path);
 // /api(!v(3.0))/user;id=0n302875106592253/article;slug=hello-world/comments
 
-console.debug(route.name, route.charge.value);
+console.debug(route.name, route.charge.get('api').value);
 // api 3.0
 
 console.debug(route.at(1).name, route.at(1).matrix.chargeOf('id').value);
@@ -136,21 +136,22 @@ import { churi } from '@hatsy/churi';
 
 console.debug(churi`
   https://example.com
-    /api(!v(${'3.0'}))
+    /api(${new UcDirective('!v', '(3.0)')})
     /user;id=${302875106592253n}
     /article;slug=${'hello-world'}
     /comments
-    ?date=since(
-      !date${'1970-01-01'}
-    )till(
-      !now
-    )
-    &range=${{
-      from: 10,
-      to: 20,
-    }}
+      ?date=${{
+        since: new UcDirective('!date', '(1970-01-01)'),
+        till: new UcEntity('!now'),
+      }}
+      &range=${{
+        from: 10,
+        to: 20,
+      }}
 `);
 ```
+
+The `UcEntity` and `UcDirective` above used to avoid escaping and percent-encoding and should be used with care.
 
 Instead, a Charged URI string can be built with `chargeURI()` and `chargeURIArgs()` functions.
 
@@ -159,7 +160,7 @@ import { chargeURI, chargeURIArgs, UcDirective, UcEntity } from '@hatsy/churi';
 
 console.debug(
   'https://example.com' +
-    `/api${chargeURIArgs(new UcDirective('!v', '(3.0)'))}` +
+    `/api(${chargeURI(new UcDirective('!v', '(3.0)'))})` +
     `/user;id=${chargeURI(302875106592253n)}` +
     `/article;slug=${chargeURI('hello-world')}` +
     '/comments' +
@@ -173,8 +174,6 @@ console.debug(
     })}`,
 );
 ```
-
-The `UcEntity` and `UcDirective` above used to avoid escaping and percent-encoding and should be used with care.
 
 Charging can be customized by implementing a `chargeURI()` method of `URIChargeable` interface. If not implemented,
 a `toJSON()` method will be used. Otherwise, predefined serialization algorithm will be applied similar to JSON

--- a/doc/uri-charge-format.md
+++ b/doc/uri-charge-format.md
@@ -65,8 +65,8 @@ String represented as [percent-encoded] value.
 
 Additionally:
 
-- Since _parentheses_ (`"(" (U+0028)` and `")" (U+0029)`) have special meaning within URI charge, they also should be
-  [percent-encoded].
+- Since _parentheses_ (`"(" (U+0028)` and `")" (U+0029)`) and _comma_ (`"," (U+002C)`) have special meaning within
+  URI charge, they should be [percent-encoded].
 - When encoded value starts with _apostrophe_ (`"'" (U+0027)`), the apostrophe is stripped, and the actual string value
   starts from the second symbol. This can be used to escape symbols that have special meaning, except _parentheses_,
   that should be [percent-encoded].
@@ -74,9 +74,10 @@ Additionally:
   meaning, they should be escaped with _apostrophe_ (`"'" (U+0027)`).
 - When string escaped with _apostrophe_, it may include balanced set of _parentheses_ (`"(" (U+0028)`
   and `")" (U+0029)`). I.e. _closing parenthesis_ should match an _opening_ one preceding it.
+  A _comma_ (`"," (U+002C)`) is considered a part of such string only if it is enclosed into parentheses.
   This may be used to place _unchanged_ URI charge as a string value.
 
-_Empty string_ may be left as is, or encoded as single _apostrophe_ (`"'" (U+0027)`).
+_Empty string_ may be left as is or encoded as single _apostrophe_ (`"'" (U+0027)`).
 
 ```
 ?first=John&middle='&last=Doe&birthday='1970-01-01
@@ -88,10 +89,10 @@ _Empty string_ may be left as is, or encoded as single _apostrophe_ (`"'" (U+002
 
 List corresponds to JavaScript [array literal].
 
-List encoded as series of item values enclosed into _parentheses_.
+List encoded as series of item values separated by _comma_ (`"," (U+002C)`).
 
 ```
-(foo)(bar)(baz)
+foo,bar,baz
 ```
 
 represents an array like
@@ -100,16 +101,55 @@ represents an array like
 ["foo", "bar", "baz"]
 ```
 
-_Empty array_ has special representation: `!!`
+Leading and trailing comma ignored within list. So the list above can be encoded as:
+
+```
+,foo,bar,baz
+foo,bar,baz,
+,foo,bar,baz,
+```
+
+_Empty list_ encoded as single _comma_ (`"," (U+002C)`). This is possible, because such comma is ignored.
+
+List with _single item_ has to contain at leas one (leading or trailing _comma_ to distinguish it from single value:
+
+```
+,foo
+foo,
+,foo,
+```
 
 An item value is encoded in URI charge format. Thus it can be anything:
 
-- boolean value: `(!)(-)`
-- number: `(-128)(127)`
-- nested array: `(('1.1)('1.2))(('2.1)('2.2))`
-- nested empty array: `(!!)`
-- `null`: `(--)`
-- empty string: `()`
+- boolean value: `!,-`
+- number: `-128,127`
+- empty string: `,'` or `,,`
+
+### Nested List
+
+An list item containing another (nested) list should be enclosed into parentheses:
+
+```
+(foo,bar),(baz)
+```
+
+represents an array like
+
+```json
+[['foo', 'bar], 'baz']
+```
+
+Note that comma is completely optional after nested list. So the list above can be encoded as:
+
+```
+(foo,bar)(baz)
+```
+
+Any level of nesting supported:
+
+```
+(1,(2.1,(2.1.1,2.1.2))((3.1.1,3.1.2)4.1)5)
+```
 
 [array literal]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#array_literals
 
@@ -141,60 +181,33 @@ An entry value is encoded in URI charge format. Thus it can be anything:
 - `null`: `is-null(--)`
 - nested map: `foo(bar(baz))`
 - nested empty map: `foo($)`
-- empty array: `foo(!!)`
+- array: `foo(bar,baz)`
+- empty array: `foo(,)`
+- multi-dimensional array: `foo((item1.1,item1.2)(item2.1,item2.2))
 - empty string: `foo()`
 
 The following rules apply to entry keys:
 
-- Since _parentheses_ (`"(" (U+0028)` and `")" (U+0029)`) have special meaning within URI charge, they should be
-  [percent-encoded].
+- Since _parentheses_ (`"(" (U+0028)` and `")" (U+0029)`) and _comma_ (`"," (U+002C)`) have special meaning within
+  URI charge, they should be [percent-encoded].
 - When encoded value starts with _dollar sign_ (`"$" (U+0024)`), the dollar sign is stripped, and the actual key value
   starts from the second symbol. This can be used to escape symbols that have special meaning, except _parentheses_,
   that should be [percent-encoded].
 - Since `"!" (U+0021)`, `"$" (U+0024)`, and `"'" (U+0027)` prefixes have special meaning, they should be escaped
   with _dollar sign_ (`"$" (U+0024)`).
-- **A non-escaped key having more than 63 octets is illegal at initial position**. It is up to the parser how to treat
+- Empty key represented by single _dollar sign_ (`"$" (U+0024)`).
+- **A non-escaped key having more than 63 octets is illegal for the first entry**. It is up to the parser how to treat
   it, or raise an error instead. This requirement allows to quickly distinguish strings and maps when processing a
-  stream. This rule makes sense only for initial key and not applied to subsequent ones.
+  stream. This rule makes sense only for the first key and not applied to subsequent ones.
 
-If entry value is an array (`foo((bar)(baz))`), it can be encoded without enclosing parentheses: `foo(bar)(baz)`.
-
-Special prefixes (`"!" (U+0021)`, `"$" (U+0024)`, `"'" (U+0027)`) have to be escaped with _dollar sign_
-(`"!" (U+0021)`).
-
-\*\*An entry key has to be prefixed with _dollar sign_
-
-A special case when key prefixed with _dollar key_ is not followed by value is treated as entry with empty string value.
+A special case when key prefixed with _dollar sign_ is not followed by value is treated as entry with empty string value.
 I.e. `$key` is the same as `$key()`. Note that this rule does not work for single `$` symbol, which stands for empty
 object. The `$()` has to be used for object with empty key and empty value (`{ '': '' }`).
 
-```
---host(google.com)4(!)
-```
-
-When entry key is empty, it has to be encoded as single _apostrophe_ (`"'" (U+0027)`):
-
-```
-'(foo)
-```
-
-corresponds to
-
-```json
-{
-  "": "foo"
-}
-```
-
-[object literal]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#object_literals
-
-### Map Suffix
-
-Map may have suffix. I.e. the last entry key without value. Such suffix is treated as entry with empty string value.
+A map may have _suffix_. I.e. the last entry key without value. Such suffix is treated as entry with empty string value.
 So, the `foo(bar)suffix` is the same as `foo(bar)suffix()` or `foo(bar)suffix(')`)
 
-Map may follow the list. Such map is treated as the last item of the list.
-So, the `(1)(2)foo(bar)suffix` is the same as `(1)(2)(foo(bar)suffix)`
+[object literal]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#object_literals
 
 ## Extensions
 
@@ -214,15 +227,17 @@ For example, the following entities supported by standard "Non-Finite Numbers" e
 ### Directive
 
 Like entity, directive starts with _exclamation mark_ (`"!" (U+0021)`) followed by directive name. In contrast to
-entity, directive accepts arguments:
+entity, directive has argument(s):
 
 ```
-!error(invalid-email)(too-short)(invalid-syntax)
+!error(invalid-email,too-short,invalid-syntax)
 ```
 
-Directive may have one argument or multiple arguments. In the latter case they have the same format as list, including
-trailing object:
+Everything after directive name is treated as directive arguments. Such arguments may include balanced parentheses and
+commas enclosed into these parentheses, just like a string escaped with _apostrophe_.
+
+It is up to directive implementation how to interpret arguments. They may or may not follow the URI charge syntax.
 
 ```
-!data(SGVsbG8sIFdvcmxkIQ)base64(!)content-type(text%2Fplain)charset(utf-8)
+!data(base64(!)content-type(text,plain)charset(utf-8)):SGVsbG8sIFdvcmxkIQ
 ```

--- a/src/charge/charge-uri.spec.ts
+++ b/src/charge/charge-uri.spec.ts
@@ -250,6 +250,21 @@ describe('chargeURI', () => {
     });
   });
 
+  describe('array value empty string item', () => {
+    it('escapes the only empty string', () => {
+      expect(chargeURI([''])).toBe(",'");
+    });
+    it('escapes leading empty string', () => {
+      expect(chargeURI(['', 'tail'])).toBe("',tail");
+    });
+    it('escapes trailing empty string', () => {
+      expect(chargeURI(['head', ''])).toBe("head,'");
+    });
+    it('does not escape empty string in the middle', () => {
+      expect(chargeURI(['head', '', 'tail'])).toBe('head,,tail');
+    });
+  });
+
   describe('array value with multiple items', () => {
     it('encoded as top-level list', () => {
       expect(chargeURI(['bar', 'baz'])).toBe('bar,baz');

--- a/src/charge/charge-uri.spec.ts
+++ b/src/charge/charge-uri.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 import { UcDirective } from '../schema/uc-directive.js';
 import { UcEntity } from '../schema/uc-entity.js';
-import { chargeURI, chargeURIArgs, chargeURIKey, unchargeURIKey } from './charge-uri.js';
+import { chargeURI, chargeURIKey, unchargeURIKey } from './charge-uri.js';
 import { parseURICharge } from './parse-uri-charge.js';
 import { URICharge } from './uri-charge.js';
 import { URIChargeable } from './uri-chargeable.js';
@@ -16,7 +16,7 @@ describe('chargeURI', () => {
       expect(chargeURI({ foo: 13n, bar: -13n })).toBe('foo(0n13)bar(-0n13)');
     });
     it('encoded as list item value', () => {
-      expect(chargeURI([13n, -13n])).toBe('(0n13)(-0n13)');
+      expect(chargeURI([13n, -13n])).toBe('0n13,-0n13');
     });
   });
 
@@ -30,8 +30,8 @@ describe('chargeURI', () => {
       expect(chargeURI({ foo: false })).toBe('foo(-)');
     });
     it('encoded as list item value', () => {
-      expect(chargeURI([true])).toBe('(!)');
-      expect(chargeURI([false])).toBe('(-)');
+      expect(chargeURI([true])).toBe(',!');
+      expect(chargeURI([false])).toBe(',-');
     });
   });
 
@@ -65,7 +65,7 @@ describe('chargeURI', () => {
       expect(chargeURI({ foo: 13, bar: -13 })).toBe('foo(13)bar(-13)');
     });
     it('encoded as list item value', () => {
-      expect(chargeURI([13, -13])).toBe('(13)(-13)');
+      expect(chargeURI([13, -13])).toBe('13,-13');
     });
     it('encodes NaN', () => {
       expect(chargeURI(NaN)).toBe('!NaN');
@@ -86,8 +86,8 @@ describe('chargeURI', () => {
       expect(chargeURI({ foo: '-test' })).toBe("foo('-test)");
     });
     it('encoded as list item value', () => {
-      expect(chargeURI(['Hello, (World)!'])).toBe('(Hello%2C%20%28World%29!)');
-      expect(chargeURI(['-test'])).toBe("('-test)");
+      expect(chargeURI(['Hello, (World)!'])).toBe(',Hello%2C%20%28World%29!');
+      expect(chargeURI(['-test'])).toBe(",'-test");
     });
     it('escapes special prefixes', () => {
       expect(chargeURI('!foo')).toBe("'!foo");
@@ -121,7 +121,7 @@ describe('chargeURI', () => {
       expect(chargeURI({ foo: null })).toBe('foo(--)');
     });
     it('encoded as list item value', () => {
-      expect(chargeURI([null])).toBe('(--)');
+      expect(chargeURI([null])).toBe(',--');
     });
   });
 
@@ -130,14 +130,14 @@ describe('chargeURI', () => {
       expect(chargeURI(undefined)).toBeUndefined();
     });
     it('is not encoded as map entry value', () => {
-      expect(chargeURI({ foo: undefined })).toBe('!()');
+      expect(chargeURI({ foo: undefined })).toBe('$');
       expect(chargeURI({ foo: undefined, bar: 1 })).toBe('bar(1)');
       expect(chargeURI({ bar: 1, foo: undefined })).toBe('bar(1)');
     });
     it('is encoded like null as array item value', () => {
-      expect(chargeURI([undefined])).toBe('(--)');
-      expect(chargeURI([1, undefined])).toBe('(1)(--)');
-      expect(chargeURI([undefined, 2])).toBe('(--)(2)');
+      expect(chargeURI([undefined])).toBe(',--');
+      expect(chargeURI([1, undefined])).toBe('1,--');
+      expect(chargeURI([undefined, 2])).toBe('--,2');
     });
   });
 
@@ -152,10 +152,10 @@ describe('chargeURI', () => {
       expect(chargeURI({ foo: { bar: { baz: 1 } } })).toBe('foo(bar(baz(1)))');
     });
     it('encoded as list item value', () => {
-      expect(chargeURI([{ foo: 'bar' }])).toBe('(foo(bar))');
+      expect(chargeURI([{ foo: 'bar' }])).toBe(',foo(bar)');
     });
     it('appended to list when last item value', () => {
-      expect(chargeURI(['', { foo: 'bar' }])).toBe('()foo(bar)');
+      expect(chargeURI(['', { foo: 'bar' }])).toBe("',foo(bar)");
     });
     it('uses custom encoder', () => {
       const obj: URIChargeable = {
@@ -194,16 +194,16 @@ describe('chargeURI', () => {
 
   describe('empty object value', () => {
     it('encoded as top-level map', () => {
-      expect(chargeURI({})).toBe('!()');
+      expect(chargeURI({})).toBe('$');
     });
     it('encoded when nested', () => {
-      expect(chargeURI({ foo: {} })).toBe('foo(!())');
+      expect(chargeURI({ foo: {} })).toBe('foo($)');
     });
     it('encoded when deeply nested', () => {
-      expect(chargeURI({ foo: { bar: {} } })).toBe('foo(bar(!()))');
+      expect(chargeURI({ foo: { bar: {} } })).toBe('foo(bar($))');
     });
     it('encoded as list item value', () => {
-      expect(chargeURI([{}])).toBe('(!())');
+      expect(chargeURI([{}])).toBe(',$');
     });
   });
 
@@ -221,7 +221,7 @@ describe('chargeURI', () => {
       expect(chargeURI({ '': 1 })).toBe('$(1)');
     });
     it('escaped when nested', () => {
-      expect(chargeURI([{ '': 1 }])).toBe('($(1))');
+      expect(chargeURI([{ '': 1 }])).toBe(',$(1)');
     });
   });
 
@@ -229,53 +229,54 @@ describe('chargeURI', () => {
     it('appended to map', () => {
       expect(chargeURI({ test1: '', test2: '', suffix: '' })).toBe('test1()test2()suffix');
     });
-    it('appended to list when last item value', () => {
-      expect(chargeURI(['', { foo: '' }])).toBe('()foo');
+    it('escaped and appended as list item value', () => {
+      expect(chargeURI(['', { foo: '' }])).toBe("',$foo");
+      expect(chargeURI(['', { '!foo': '' }])).toBe("',$!foo");
     });
   });
 
   describe('array value with one item', () => {
     it('encoded as top-level list', () => {
-      expect(chargeURI(['bar'])).toBe('(bar)');
+      expect(chargeURI(['bar'])).toBe(',bar');
     });
     it('encoded as map entry value', () => {
-      expect(chargeURI({ foo: ['bar'] })).toBe('foo((bar))');
+      expect(chargeURI({ foo: ['bar'] })).toBe('foo(,bar)');
     });
     it('encoded as nested list item value', () => {
-      expect(chargeURI([['bar']])).toBe('((bar))');
+      expect(chargeURI([['bar']])).toBe('(bar)');
     });
     it('encoded as deeply nested list item value', () => {
-      expect(chargeURI([[['bar']]])).toBe('(((bar)))');
+      expect(chargeURI([[['bar']]])).toBe('((bar))');
     });
   });
 
   describe('array value with multiple items', () => {
     it('encoded as top-level list', () => {
-      expect(chargeURI(['bar', 'baz'])).toBe('(bar)(baz)');
+      expect(chargeURI(['bar', 'baz'])).toBe('bar,baz');
     });
     it('encoded as map entry value', () => {
-      expect(chargeURI({ foo: ['bar', 'baz'] })).toBe('foo(bar)(baz)');
+      expect(chargeURI({ foo: ['bar', 'baz'] })).toBe('foo(bar,baz)');
     });
     it('encoded as nested list item value', () => {
-      expect(chargeURI([['bar', 'baz']])).toBe('((bar)(baz))');
+      expect(chargeURI([['bar', 'baz']])).toBe('(bar,baz)');
     });
     it('encoded as deeply nested list item value', () => {
-      expect(chargeURI([[['bar', 'baz']]])).toBe('(((bar)(baz)))');
+      expect(chargeURI([[['bar', 'baz']]])).toBe('((bar,baz))');
     });
   });
 
   describe('empty array value', () => {
     it('encoded as top-level list', () => {
-      expect(chargeURI([])).toBe('!!');
+      expect(chargeURI([])).toBe(',');
     });
     it('encoded as map entry value', () => {
-      expect(chargeURI({ foo: [] })).toBe('foo(!!)');
+      expect(chargeURI({ foo: [] })).toBe('foo(,)');
     });
     it('encoded as nested list item value', () => {
-      expect(chargeURI([[]])).toBe('(!!)');
+      expect(chargeURI([[]])).toBe('()');
     });
     it('encoded as deeply nested list item value', () => {
-      expect(chargeURI([[[]]])).toBe('((!!))');
+      expect(chargeURI([[[]]])).toBe('(())');
     });
   });
 
@@ -287,7 +288,7 @@ describe('chargeURI', () => {
       expect(chargeURI({ foo: new UcEntity('!test') })).toBe('foo(!test)');
     });
     it('encoded as list item value', () => {
-      expect(chargeURI([new UcEntity('!test')])).toBe('(!test)');
+      expect(chargeURI([new UcEntity('!test')])).toBe(',!test');
     });
   });
 
@@ -299,7 +300,7 @@ describe('chargeURI', () => {
       expect(chargeURI({ foo: new UcDirective('!test', '(bar)') })).toBe('foo(!test(bar))');
     });
     it('encoded as list item value', () => {
-      expect(chargeURI([new UcDirective('!test', '(foo)')])).toBe('(!test(foo))');
+      expect(chargeURI([new UcDirective('!test', '(foo)')])).toBe(',!test(foo)');
     });
   });
 
@@ -320,39 +321,6 @@ describe('chargeURI', () => {
       expect(String(URICharge.none)).toBe('!None');
       expect(chargeURI(URICharge.none)).toBeUndefined();
     });
-  });
-});
-
-describe('chargeURIArgs', () => {
-  it('encloses single value into parentheses', () => {
-    expect(chargeURIArgs('test')).toBe('(test)');
-  });
-  it('encloses `null` into parentheses', () => {
-    expect(chargeURIArgs(null)).toBe('(--)');
-  });
-  it('encloses empty map into parentheses', () => {
-    expect(chargeURIArgs({})).toBe('(!())');
-  });
-  it('encloses non-empty map into parentheses', () => {
-    expect(chargeURIArgs({ foo: 'bar' })).toBe('(foo(bar))');
-  });
-  it('appends suffix', () => {
-    expect(chargeURIArgs({ foo: 'bar', suffix: '' })).toBe('(foo(bar)suffix)');
-  });
-  it('does not append the only suffix', () => {
-    expect(chargeURIArgs({ suffix: '' })).toBe('(suffix())');
-  });
-  it('encloses empty list into parentheses', () => {
-    expect(chargeURIArgs([])).toBe('(!!)');
-  });
-  it('encloses list with one element into parentheses', () => {
-    expect(chargeURIArgs([1])).toBe('((1))');
-  });
-  it('does not enclose list with two elements into parentheses', () => {
-    expect(chargeURIArgs([1, 2])).toBe('(1)(2)');
-  });
-  it('does not encode unsupported values', () => {
-    expect(chargeURIArgs(Symbol('unsupported'))).toBeUndefined();
   });
 });
 

--- a/src/charge/churi.tag.spec.ts
+++ b/src/charge/churi.tag.spec.ts
@@ -115,9 +115,9 @@ describe('churi tag', () => {
     expect(churi`${[]},`).toBe('(),');
     expect(churi`?p=${[]},`).toBe('?p=(),');
   });
-  it('charges undefined value as !undef entity', () => {
-    expect(churi`${undefined}`).toBe('!undef');
-    expect(churi`?p=${undefined}`).toBe('?p=!undef');
+  it('charges undefined value as null', () => {
+    expect(churi`${undefined}`).toBe('--');
+    expect(churi`?p=${undefined}`).toBe('?p=--');
   });
   it('charges undefined list item as null', () => {
     expect(churi`,${undefined}`).toBe(',--');

--- a/src/charge/churi.tag.spec.ts
+++ b/src/charge/churi.tag.spec.ts
@@ -101,6 +101,18 @@ describe('churi tag', () => {
     expect(churi`${list},`).toBe("('11,'22),");
     expect(churi`?p=${list},`).toBe("?p=('11,'22),");
   });
+  it('charges many nested lists', () => {
+    const first = ['a11', 'a22'];
+    const second = ['b11', 'b22'];
+
+    expect(churi`(${first}${second})`).toBe('((a11,a22)(b11,b22))');
+    expect(churi`${first}${second}`).toBe('(a11,a22)(b11,b22)');
+    expect(churi`,${first}${second}`).toBe(',(a11,a22)(b11,b22)');
+    expect(churi`${first},${second}`).toBe('(a11,a22),(b11,b22)');
+    expect(churi`,${first},${second}`).toBe(',(a11,a22),(b11,b22)');
+    expect(churi`?p=${first}${second}`).toBe('?p=(a11,a22)(b11,b22)');
+    expect(churi`?p=${first},${second}`).toBe('?p=(a11,a22),(b11,b22)');
+  });
   it('charges nested list with single item', () => {
     const list = ['11'];
 

--- a/src/charge/churi.tag.spec.ts
+++ b/src/charge/churi.tag.spec.ts
@@ -35,16 +35,16 @@ describe('churi tag', () => {
 
     expect(churi`${string}`).toBe("'13");
   });
-  it('escapes top-level argument', () => {
+  it('escapes top-level list items', () => {
     const prefix = '11';
     const arg = '22';
 
-    expect(churi`${prefix}${arg}`).toBe("('11)('22)");
+    expect(churi`${prefix},${arg}`).toBe("'11,'22");
   });
   it('escapes arg', () => {
     const string = '13';
 
-    expect(churi`/path${string}`).toBe("/path('13)");
+    expect(churi`/path${string}`).toBe("/path'13");
   });
   it('escapes value', () => {
     const string = '13';
@@ -56,50 +56,71 @@ describe('churi tag', () => {
 
     expect(churi`?p=${string}`).toBe("?p='13");
   });
-  it('escapes list item values', () => {
+  it('charges multiple values', () => {
     const first = '11';
     const second = '22';
 
-    expect(churi`?p=(${first})(${second})`).toBe("?p=('11)('22)");
+    expect(churi`?p1=${first}&p2=${second}`).toBe("?p1='11&p2='22");
   });
-  it('escapes map entry values', () => {
+  it('charges single list item', () => {
+    const value = 'test';
+
+    expect(churi`,${value}`).toBe(',test');
+    expect(churi`${value},`).toBe('test,');
+    expect(churi`?p=,${value}`).toBe('?p=,test');
+    expect(churi`?p=${value},`).toBe('?p=test,');
+  });
+  it('charges list items without comma', () => {
     const first = '11';
     const second = '22';
 
-    expect(churi`?p=foo(${first})(${second})`).toBe("?p=foo('11)('22)");
+    expect(churi`${first}${second}`).toBe("'11,'22");
+    expect(churi`?p=${first}${second}`).toBe("?p='11,'22");
   });
-  it('escapes map entry args', () => {
-    const first = '11';
-    const second = '22';
+  it('charges list', () => {
+    const list = ['11', '22'];
 
-    expect(churi`?p=foo${first}${second}`).toBe("?p=foo('11)('22)");
+    expect(churi`${list}`).toBe("'11,'22");
+    expect(churi`?p=${list}`).toBe("?p='11,'22");
   });
-  it('escapes directive args', () => {
-    const first = '11';
-    const second = '22';
+  it('charges list with single item', () => {
+    const list = ['11'];
 
-    expect(churi`?p=!dir${first}${second}`).toBe("?p=!dir('11)('22)");
+    expect(churi`${list}`).toBe(",'11");
+    expect(churi`?p=${list}`).toBe("?p=,'11");
   });
-  it('escapes directive args in parentheses', () => {
-    const first = '11';
-    const second = '22';
-
-    expect(churi`?p=!dir(${first})(${second})`).toBe("?p=!dir('11)('22)");
+  it('charges empty list', () => {
+    expect(churi`${[]}`).toBe(',');
+    expect(churi`?p=${[]}`).toBe('?p=,');
   });
-  it('escapes directive arg list', () => {
-    const args = ['11', '22'];
+  it('charges nested list', () => {
+    const list = ['11', '22'];
 
-    expect(churi`?p=!dir${args}`).toBe("?p=!dir('11)('22)");
+    expect(churi`(${list})`).toBe("(('11,'22))");
+    expect(churi`,${list}`).toBe(",('11,'22)");
+    expect(churi`${list},`).toBe("('11,'22),");
+    expect(churi`?p=${list},`).toBe("?p=('11,'22),");
   });
-  it('escapes directive list arg items', () => {
-    const args = ['11', '22'];
+  it('charges nested list with single item', () => {
+    const list = ['11'];
 
-    expect(churi`?p=!dir(${args})`).toBe("?p=!dir(('11)('22))");
+    expect(churi`(${list})`).toBe("(('11))");
+    expect(churi`,${list}`).toBe(",('11)");
+    expect(churi`${list},`).toBe("('11),");
+    expect(churi`?p=${list},`).toBe("?p=('11),");
   });
-  it('escapes subsequent directive args in parentheses', () => {
-    const first = '11';
-    const second = '22';
-
-    expect(churi`?p=!dir(${first}${second})`).toBe("?p=!dir(('11)('22))");
+  it('charges empty nested list', () => {
+    expect(churi`(${[]})`).toBe('(())');
+    expect(churi`,${[]}`).toBe(',()');
+    expect(churi`${[]},`).toBe('(),');
+    expect(churi`?p=${[]},`).toBe('?p=(),');
+  });
+  it('charges undefined value as !undef entity', () => {
+    expect(churi`${undefined}`).toBe('!undef');
+    expect(churi`?p=${undefined}`).toBe('?p=!undef');
+  });
+  it('charges undefined list item as null', () => {
+    expect(churi`,${undefined}`).toBe(',--');
+    expect(churi`${undefined},`).toBe('--,');
   });
 });

--- a/src/charge/churi.tag.ts
+++ b/src/charge/churi.tag.ts
@@ -100,8 +100,8 @@ export function churi(strings: TemplateStringsArray, ...values: unknown[]): stri
 
       commaRequired = commaAfter;
     } else {
-      // Substitute `!undef` entity for undefined item.
-      uri += chargeURI(value) ?? '!undef';
+      // Substitute `null` for undefined value.
+      uri += chargeURI(value) ?? '--';
     }
 
     index = nextIndex;

--- a/src/charge/impl/uc-value-decoder.ts
+++ b/src/charge/impl/uc-value-decoder.ts
@@ -65,8 +65,6 @@ function decodeExclamationPrefixedUcValue<TValue, TCharge>(
 ): void {
   if (input.length === 1) {
     rx.addValue(true, 'boolean');
-  } else if (input === '!!') {
-    rx.rxList(listRx => listRx.end());
   } else {
     ext.parseEntity(rx, input);
   }

--- a/src/charge/impl/uc-value-parser.ts
+++ b/src/charge/impl/uc-value-parser.ts
@@ -83,13 +83,6 @@ function parseUcSingle<TValue, TCharge>(
 
   if (delimiter !== '(') {
     // End of the value.
-    if (delimiter === ',' && (input.length < 2 || input[1] === ')')) {
-      // Ignore trailing comma.
-      rx.asList();
-
-      return delimiterIdx + 1;
-    }
-
     decodeUcValue(rx, ext, input.slice(0, delimiterIdx));
 
     return delimiterIdx;

--- a/src/charge/impl/uri-charge.some.ts
+++ b/src/charge/impl/uri-charge.some.ts
@@ -153,7 +153,7 @@ export class URICharge$Map<out TValue>
   }
 
   override chargeURI(placement: URIChargeable.Placement): string {
-    return chargeURIMap(this.#map, this.#map.size, placement);
+    return chargeURIMap(this.#map, placement);
   }
 
 }

--- a/src/charge/impl/uri-chargeable.placement.ts
+++ b/src/charge/impl/uri-chargeable.placement.ts
@@ -2,5 +2,6 @@ import { URIChargeable } from '../uri-chargeable.js';
 
 export const ANY_CHARGE_PLACEMENT: URIChargeable.Any = {
   as: undefined,
-  omitParentheses: undefined,
+  omitCommaBefore: undefined,
+  omitCommaAfter: undefined,
 };

--- a/src/charge/mod.ts
+++ b/src/charge/mod.ts
@@ -1,4 +1,4 @@
-export { chargeURI, chargeURIArgs, chargeURIKey, unchargeURIKey } from './charge-uri.js';
+export { chargeURI, chargeURIKey, unchargeURIKey } from './charge-uri.js';
 export * from './churi.tag.js';
 export * from './opaque.uri-charge-rx.js';
 export * from './parse-uc-value.js';

--- a/src/charge/opaque.uri-charge-rx.ts
+++ b/src/charge/opaque.uri-charge-rx.ts
@@ -36,17 +36,6 @@ export class OpaqueURIChargeRx<out TValue = UcPrimitive, out TCharge = unknown>
     return OpaqueURICharge$MapRx;
   }
 
-  /**
-   * Opaque URI charge list receiver.
-   *
-   * Ignores charges and always results to {@link OpaqueURIChargeRx#none none}.
-   *
-   * Can be used as a base for other implementations.
-   */
-  static get ListRx(): URIChargeRx.ValueRx.Constructor {
-    return OpaqueURICharge$ListRx;
-  }
-
   readonly #none: TCharge;
 
   constructor({ none }: URIChargeRx.Init<TCharge>) {
@@ -87,11 +76,8 @@ export class OpaqueURIChargeRx<out TValue = UcPrimitive, out TCharge = unknown>
 
 }
 
-abstract class OpaqueURICharge$AbstractRx<
-  out TValue,
-  out TCharge,
-  out TRx extends URIChargeRx<TValue, TCharge>,
-> implements URIChargeRx.ValueRx<TValue, TCharge, TRx> {
+class OpaqueURICharge$ValueRx<out TValue, out TCharge, out TRx extends URIChargeRx<TValue, TCharge>>
+  implements URIChargeRx.ValueRx<TValue, TCharge, TRx> {
 
   readonly #chargeRx: TRx;
 
@@ -103,7 +89,9 @@ abstract class OpaqueURICharge$AbstractRx<
     return this.#chargeRx;
   }
 
-  abstract add(charge: TCharge): void;
+  add(_charge: TCharge): void {
+    // Ignore charge.
+  }
 
   addDirective(rawName: string, rawArg: string): void {
     this.add(this.#chargeRx.createDirective(rawName, rawArg));
@@ -125,56 +113,12 @@ abstract class OpaqueURICharge$AbstractRx<
     this.add(this.chargeRx.rxList(build));
   }
 
-  abstract asList(build: (rx: URIChargeRx.ValueRx<TValue, TCharge>) => TCharge): void;
+  asList(): void {
+    // Does nothing.
+  }
 
   end(): TCharge {
     return this.#chargeRx.none;
-  }
-
-}
-
-class OpaqueURICharge$ValueRx<
-  out TValue,
-  out TCharge,
-  out TRx extends URIChargeRx<TValue, TCharge>,
-> extends OpaqueURICharge$AbstractRx<TValue, TCharge, TRx> {
-
-  #charge?: [TCharge];
-
-  override add(charge: TCharge): void {
-    this.#charge = [charge];
-  }
-
-  override asList(build: (rx: URIChargeRx.ValueRx<TValue, TCharge>) => TCharge): void {
-    if (this.#charge) {
-      const [charge] = this.#charge;
-
-      this.chargeRx.rxList(rx => {
-        rx.add(charge);
-
-        return build(rx);
-      });
-    } else {
-      this.chargeRx.rxList(build);
-    }
-  }
-
-}
-
-class OpaqueURICharge$ListRx<
-  out TValue,
-  out TCharge,
-  out TRx extends URIChargeRx<TValue, TCharge>,
-> extends OpaqueURICharge$AbstractRx<TValue, TCharge, TRx> {
-
-  override add(_charge: TCharge): void {
-    // Ignore charge
-  }
-
-  override asList(
-    build: (rx: URIChargeRx.ValueRx<TValue, TCharge, URIChargeRx<TValue, TCharge>>) => TCharge,
-  ): void {
-    build(this);
   }
 
 }

--- a/src/charge/parse-uc-value.spec.ts
+++ b/src/charge/parse-uc-value.spec.ts
@@ -152,6 +152,18 @@ describe('parseUcValue', () => {
     });
   });
 
+  describe('empty list item', () => {
+    it('recognized as top-level value', () => {
+      expect(parse(',,')).toEqual({ charge: [''], end: 2 });
+    });
+    it('recognized as map entry value', () => {
+      expect(parse('foo(,,)').charge).toEqual({ foo: [''] });
+    });
+    it('recognized as nested list item value', () => {
+      expect(parse('(,,)')).toEqual({ charge: [['']], end: 4 });
+    });
+  });
+
   describe('null value', () => {
     it('recognized as top-level value', () => {
       expect(parse('--')).toEqual({ charge: null, end: 2 });
@@ -437,6 +449,9 @@ describe('parseUcValue', () => {
     expect(parse(',(foo))')).toEqual({ charge: [['foo']], end: 6 });
     expect(parse('(foo),)')).toEqual({ charge: [['foo']], end: 6 });
     expect(parse(',(foo),)')).toEqual({ charge: [['foo']], end: 7 });
+  });
+  it('stops nested list parsing after comma', () => {
+    expect(parse('(foo,bar,')).toEqual({ charge: [['foo', 'bar']], end: 9 });
   });
   it('stops entries parsing at closing parent', () => {
     expect(parse('foo(bar))')).toEqual({ charge: { foo: 'bar' }, end: 8 });

--- a/src/charge/parse-uc-value.spec.ts
+++ b/src/charge/parse-uc-value.spec.ts
@@ -1,7 +1,6 @@
-import { beforeEach, describe, expect, it } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { UcDirective } from '../schema/uc-directive.js';
 import { UcEntity } from '../schema/uc-entity.js';
-import { UcPrimitive } from '../schema/uc-primitive.js';
 import { UcValue } from '../schema/uc-value.js';
 import { createUcValueParser, parseUcValue } from './parse-uc-value.js';
 import { UcValueBuilder } from './uc-value-builder.js';
@@ -13,32 +12,6 @@ describe('createUcValueParser', () => {
   });
   it('returns new instance with options', () => {
     expect(createUcValueParser({})).not.toBe(createUcValueParser());
-  });
-
-  describe('parseArgs', () => {
-    let parser: URIChargeParser<UcPrimitive, UcValue>;
-
-    beforeEach(() => {
-      parser = createUcValueParser();
-    });
-
-    it('recognizes single arg', () => {
-      expect(parser.parseArgs('Hello,%20World!')).toEqual({ charge: 'Hello, World!', end: 15 });
-    });
-    it('recognizes arg with custom receiver', () => {
-      expect(parser.chargeRx.rxValue(rx => parser.parseArgs('Hello,%20World!', rx).charge)).toBe(
-        'Hello, World!',
-      );
-    });
-    it('recognizes arg in parentheses', () => {
-      expect(parser.parseArgs('(Hello,%20World!)')).toEqual({ charge: 'Hello, World!', end: 17 });
-    });
-    it('recognizes multiple args', () => {
-      expect(parser.parseArgs('(Hello,%20World!)foo(bar)suffix')).toEqual({
-        charge: ['Hello, World!', { foo: 'bar', suffix: '' }],
-        end: 31,
-      });
-    });
   });
 
   describe('rxValue', () => {
@@ -54,7 +27,7 @@ describe('createUcValueParser', () => {
 describe('parseUcValue', () => {
   describe('string value', () => {
     it('recognized as top-level value', () => {
-      expect(parse('Hello,%20World!')).toEqual({ charge: 'Hello, World!', end: 15 });
+      expect(parse('Hello!%20World!')).toEqual({ charge: 'Hello! World!', end: 15 });
     });
     it('recognized as map entry value', () => {
       expect(parse('foo(bar)').charge).toEqual({ foo: 'bar' });
@@ -78,7 +51,7 @@ describe('parseUcValue', () => {
       expect(parse("foo('bar)").charge).toEqual({ foo: 'bar' });
     });
     it('recognized as list item value', () => {
-      expect(parse("('bar)").charge).toEqual(['bar']);
+      expect(parse(",'bar").charge).toEqual(['bar']);
     });
     it('includes balanced parenthesis', () => {
       expect(parse("'foo(bar,baz)suffix").charge).toBe('foo(bar,baz)suffix');
@@ -95,9 +68,6 @@ describe('parseUcValue', () => {
     it('recognized as map entry value', () => {
       expect(parse('foo()').charge).toEqual({ foo: '' });
     });
-    it('recognizes as list item value', () => {
-      expect(parse('()').charge).toEqual(['']);
-    });
   });
 
   describe('empty quoted string value', () => {
@@ -111,11 +81,19 @@ describe('parseUcValue', () => {
       expect(parse("foo(')").charge).toEqual({ foo: '' });
     });
     it('recognizes as list item value', () => {
-      expect(parse("(')").charge).toEqual(['']);
+      expect(parse("',").charge).toEqual(['']);
+      expect(parse(",'").charge).toEqual(['']);
+      expect(parse(",',").charge).toEqual(['']);
     });
   });
 
   describe('bigint value', () => {
+    it('recognized as top-level value', () => {
+      expect(parse('0n13').charge).toBe(13n);
+      expect(parse('-0n13').charge).toBe(-13n);
+      expect(parse('0n').charge).toBe(0n);
+      expect(parse('-0n').charge).toBe(0n);
+    });
     it('recognized as map entry value', () => {
       expect(parse('foo(0n13)').charge).toEqual({ foo: 13n });
       expect(parse('foo(-0n13)').charge).toEqual({ foo: -13n });
@@ -123,21 +101,29 @@ describe('parseUcValue', () => {
       expect(parse('foo(-0n)').charge).toEqual({ foo: 0n });
     });
     it('recognized as list item value', () => {
-      expect(parse('(0n13)').charge).toEqual([13n]);
-      expect(parse('(-0n13)').charge).toEqual([-13n]);
-      expect(parse('(0n)').charge).toEqual([0n]);
-      expect(parse('(-0n)').charge).toEqual([0n]);
+      expect(parse(',0n13,').charge).toEqual([13n]);
+      expect(parse(',-0n13,').charge).toEqual([-13n]);
+      expect(parse(',0n,').charge).toEqual([0n]);
+      expect(parse(',-0n,').charge).toEqual([0n]);
     });
   });
 
   describe('boolean value', () => {
+    it('recognized as top-level value', () => {
+      expect(parse('!').charge).toBe(true);
+      expect(parse('-').charge).toBe(false);
+    });
     it('recognized as map entry value', () => {
       expect(parse('foo(!)').charge).toEqual({ foo: true });
       expect(parse('foo(-)').charge).toEqual({ foo: false });
     });
     it('recognized as list item value', () => {
-      expect(parse('(!)').charge).toEqual([true]);
-      expect(parse('(-)').charge).toEqual([false]);
+      expect(parse(',!').charge).toEqual([true]);
+      expect(parse('!,').charge).toEqual([true]);
+      expect(parse(',!,').charge).toEqual([true]);
+      expect(parse(',-').charge).toEqual([false]);
+      expect(parse('-,').charge).toEqual([false]);
+      expect(parse(',-,').charge).toEqual([false]);
     });
   });
 
@@ -149,19 +135,20 @@ describe('parseUcValue', () => {
       expect(parse('foo($)').charge).toEqual({ foo: {} });
     });
     it('recognized as list item value', () => {
-      expect(parse('($)').charge).toEqual([{}]);
+      expect(parse(',$').charge).toEqual([{}]);
     });
   });
 
   describe('empty list', () => {
     it('recognized as top-level value', () => {
-      expect(parse('!!')).toEqual({ charge: [], end: 2 });
+      expect(parse(',')).toEqual({ charge: [], end: 1 });
     });
     it('recognized as map entry value', () => {
-      expect(parse('foo(!!)').charge).toEqual({ foo: [] });
+      expect(parse('foo(,)').charge).toEqual({ foo: [] });
     });
-    it('recognized as list item value', () => {
-      expect(parse('(!!)').charge).toEqual([[]]);
+    it('recognized as nested list item value', () => {
+      expect(parse('()')).toEqual({ charge: [[]], end: 2 });
+      expect(parse('(,)')).toEqual({ charge: [[]], end: 3 });
     });
   });
 
@@ -173,7 +160,8 @@ describe('parseUcValue', () => {
       expect(parse('foo(--)').charge).toEqual({ foo: null });
     });
     it('recognized as list item value', () => {
-      expect(parse('(--)').charge).toEqual([null]);
+      expect(parse(',--').charge).toEqual([null]);
+      expect(parse('--,').charge).toEqual([null]);
     });
   });
 
@@ -195,12 +183,12 @@ describe('parseUcValue', () => {
       expect(parse('foo(-0)').charge).toEqual({ foo: -0 });
     });
     it('recognized as list item value', () => {
-      expect(parse('(123E-2)').charge).toEqual([123e-2]);
-      expect(parse('(%3123E-2)').charge).toEqual([123e-2]);
-      expect(parse('(-123E-2)').charge).toEqual([-123e-2]);
-      expect(parse('(%2D123E-2)').charge).toEqual([-123e-2]);
-      expect(parse('(0)').charge).toEqual([0]);
-      expect(parse('(-0)').charge).toEqual([-0]);
+      expect(parse(',123E-2').charge).toEqual([123e-2]);
+      expect(parse(',%3123E-2)').charge).toEqual([123e-2]);
+      expect(parse(',-123E-2').charge).toEqual([-123e-2]);
+      expect(parse(',%2D123E-2').charge).toEqual([-123e-2]);
+      expect(parse(',0').charge).toEqual([0]);
+      expect(parse(',-0)').charge).toEqual([-0]);
     });
   });
 
@@ -232,49 +220,70 @@ describe('parseUcValue', () => {
       });
     });
     it('recognized as list item value', () => {
-      expect(parse('(!bar%20baz)').charge).toEqual([new UcEntity('!bar%20baz')]);
+      expect(parse(',!bar%20baz').charge).toEqual([new UcEntity('!bar%20baz')]);
+      expect(parse('!bar%20baz,').charge).toEqual([new UcEntity('!bar%20baz')]);
+      expect(parse(',!bar%20baz,').charge).toEqual([new UcEntity('!bar%20baz')]);
     });
   });
 
   describe('list value', () => {
     it('recognized as top-level value with one item', () => {
-      expect(parse('(123)').charge).toEqual([123]);
+      expect(parse('123,').charge).toEqual([123]);
+      expect(parse(',123').charge).toEqual([123]);
+      expect(parse(',123,').charge).toEqual([123]);
     });
     it('recognized as top-level value', () => {
-      expect(parse('(123)(456)').charge).toEqual([123, 456]);
+      expect(parse('123,456').charge).toEqual([123, 456]);
     });
     it('recognized as map entry value', () => {
-      expect(parse('foo(1)(bar)()').charge).toEqual({
+      expect(parse("foo(1,bar,')").charge).toEqual({
         foo: [1, 'bar', ''],
       });
     });
     it('recognized as map entry value with leading empty string', () => {
-      expect(parse('foo()(1)').charge).toEqual({
+      expect(parse("foo(',1)").charge).toEqual({
         foo: ['', 1],
       });
     });
-    it('recognized with multiple items', () => {
+    it('recognized as multiple nested lists', () => {
       expect(parse('foo((1)(bar)())').charge).toEqual({
-        foo: [1, 'bar', ''],
+        foo: [[1], ['bar'], []],
       });
     });
-    it('recognized with single item', () => {
+    it('recognized as single nested list', () => {
       expect(parse('foo((1))').charge).toEqual({
-        foo: [1],
+        foo: [[1]],
       });
     });
-    it('recognized with single item containing empty string', () => {
+    it('recognized as single empty nested list', () => {
       expect(parse('foo(())').charge).toEqual({
-        foo: [''],
+        foo: [[]],
       });
     });
-    it('recognized when nested', () => {
+    it('recognized when deeply nested', () => {
       expect(parse('foo(((1)(bar)(!))((2)(baz)(-)))').charge).toEqual({
         foo: [
-          [1, 'bar', true],
-          [2, 'baz', false],
+          [[1], ['bar'], [true]],
+          [[2], ['baz'], [false]],
         ],
       });
+    });
+    it('ignores leading comma', () => {
+      expect(parse(',(2),(baz)(-)').charge).toEqual([[2], ['baz'], [false]]);
+      expect(parse('(,(2),(baz)(-))').charge).toEqual([[[2], ['baz'], [false]]]);
+    });
+    it('ignores trailing comma', () => {
+      expect(parse('(2),(baz)(-),').charge).toEqual([[2], ['baz'], [false]]);
+      expect(parse('((2),(baz)(-),)').charge).toEqual([[[2], ['baz'], [false]]]);
+    });
+    it('ignores both leading and trailing commas', () => {
+      expect(parse(',(2),(baz)(-),').charge).toEqual([[2], ['baz'], [false]]);
+      expect(parse('(,(2),(baz)(-),)').charge).toEqual([[[2], ['baz'], [false]]]);
+    });
+    it('ignores the only comma', () => {
+      expect(parse(',').charge).toEqual([]);
+      expect(parse('(,)').charge).toEqual([[]]);
+      expect(parse('((,))').charge).toEqual([[[]]]);
     });
   });
 
@@ -309,7 +318,7 @@ describe('parseUcValue', () => {
       });
     });
     it('recognized after list-valued entry', () => {
-      expect(parse('foo(1)(bar)test(-)').charge).toEqual({
+      expect(parse('foo(1,bar)test(-)').charge).toEqual({
         foo: [1, 'bar'],
         test: false,
       });
@@ -319,40 +328,44 @@ describe('parseUcValue', () => {
         foo: '',
       });
     });
-    it('treated as trailing map of top-level list', () => {
-      expect(parse('(123)(456)foo(test)bar(1)tail').charge).toEqual([
+    it('treated as trailing item of top-level list', () => {
+      expect(parse('123,456,foo(test)bar(1)tail').charge).toEqual([
         123,
         456,
         { foo: 'test', bar: 1, tail: '' },
       ]);
+      expect(parse('(123)(456)foo(test)bar(1)tail').charge).toEqual([
+        [123],
+        [456],
+        { foo: 'test', bar: 1, tail: '' },
+      ]);
     });
-    it('treated as trailing map-valued item of the list', () => {
+    it('treated as trailing item of list-valued entry', () => {
       expect(parse('foo(bar((1)(2)test(3))))').charge).toEqual({
+        foo: { bar: [[1], [2], { test: 3 }] },
+      });
+      expect(parse('foo(bar(1,2,test(3))))').charge).toEqual({
         foo: { bar: [1, 2, { test: 3 }] },
       });
     });
   });
 
-  describe('map suffix', () => {
+  describe('suffix', () => {
     it('parsed for top-level map', () => {
       expect(parse('foo(456)suffix').charge).toEqual({ foo: 456, suffix: '' });
     });
-    it('treated as trailing map-valued item of top-level list', () => {
-      expect(parse('(123)(456)foo').charge).toEqual([123, 456, { foo: '' }]);
+    it('treated as trailing string item after nested list', () => {
+      expect(parse('(123)(456)foo').charge).toEqual([[123], [456], 'foo']);
+      expect(parse('foo(bar(1)(2)test))').charge).toEqual({
+        foo: [{ bar: 1 }, [2], 'test'],
+      });
+      expect(parse('foo(bar((1)(2)test)))').charge).toEqual({
+        foo: { bar: [[1], [2], 'test'] },
+      });
     });
     it('treated as map entry containing empty string after single-valued entry', () => {
       expect(parse('foo(bar(baz)test))').charge).toEqual({
         foo: { bar: 'baz', test: '' },
-      });
-    });
-    it('treated as map entry containing empty string after list-valued entry', () => {
-      expect(parse('foo(bar(1)(2)test))').charge).toEqual({
-        foo: { bar: [1, 2], test: '' },
-      });
-    });
-    it('treated as trailing item containing map after list', () => {
-      expect(parse('foo(bar((1)(2)test)))').charge).toEqual({
-        foo: { bar: [1, 2, { test: '' }] },
       });
     });
   });
@@ -375,7 +388,7 @@ describe('parseUcValue', () => {
       expect(rawArg).toBe('(1)');
     });
     it('recognized as list item value', () => {
-      const [{ rawName, rawArg }] = parse('(!bar%20baz())').charge as [UcDirective];
+      const [{ rawName, rawArg }] = parse(',!bar%20baz()').charge as [UcDirective];
 
       expect(rawName).toBe('!bar%20baz');
       expect(rawArg).toBe('()');
@@ -388,7 +401,7 @@ describe('parseUcValue', () => {
     });
   });
   it('overrides list', () => {
-    expect(parse('foo(bar)(baz)foo(bar1)(baz1)foo(bar2)(baz2)').charge).toEqual({
+    expect(parse('foo(bar,baz)foo(bar1,baz1)foo(bar2,baz2)').charge).toEqual({
       foo: ['bar2', 'baz2'],
     });
   });
@@ -398,7 +411,7 @@ describe('parseUcValue', () => {
     });
   });
   it('concatenates maps', () => {
-    expect(parse('foo(bar(test)(test2))(bar(baz(1)test(!)))(bar(baz(2)test(-)))').charge).toEqual({
+    expect(parse('foo(bar(test,test2),bar(baz(1)test(!)),bar(baz(2)test(-)))').charge).toEqual({
       foo: [
         { bar: ['test', 'test2'] },
         { bar: { baz: 1, test: true } },
@@ -407,15 +420,23 @@ describe('parseUcValue', () => {
     });
   });
   it('concatenates map and value', () => {
-    expect(parse('foo(bar(baz(1))(test))').charge).toEqual({
+    expect(parse('foo(bar(baz(1),test))').charge).toEqual({
       foo: { bar: [{ baz: 1 }, 'test'] },
     });
   });
   it('stops simple value parsing at closing parent', () => {
     expect(parse('foo)')).toEqual({ charge: 'foo', end: 3 });
   });
-  it('stops top-level kist parsing at closing parent', () => {
-    expect(parse('(foo))')).toEqual({ charge: ['foo'], end: 5 });
+  it('stops top-level list parsing at closing parent', () => {
+    expect(parse(',foo)')).toEqual({ charge: ['foo'], end: 4 });
+    expect(parse('foo,)')).toEqual({ charge: ['foo'], end: 4 });
+    expect(parse(',foo,)')).toEqual({ charge: ['foo'], end: 5 });
+  });
+  it('stops nested list parsing at closing parent', () => {
+    expect(parse('(foo))')).toEqual({ charge: [['foo']], end: 5 });
+    expect(parse(',(foo))')).toEqual({ charge: [['foo']], end: 6 });
+    expect(parse('(foo),)')).toEqual({ charge: [['foo']], end: 6 });
+    expect(parse(',(foo),)')).toEqual({ charge: [['foo']], end: 7 });
   });
   it('stops entries parsing at closing parent', () => {
     expect(parse('foo(bar))')).toEqual({ charge: { foo: 'bar' }, end: 8 });

--- a/src/charge/parse-uc-value.spec.ts
+++ b/src/charge/parse-uc-value.spec.ts
@@ -80,6 +80,9 @@ describe('parseUcValue', () => {
     it('recognized as list item value', () => {
       expect(parse("('bar)").charge).toEqual(['bar']);
     });
+    it('includes balanced parenthesis', () => {
+      expect(parse("'foo(bar,baz)suffix").charge).toBe('foo(bar,baz)suffix');
+    });
   });
 
   describe('empty string value', () => {

--- a/src/charge/parse-uc-value.spec.ts
+++ b/src/charge/parse-uc-value.spec.ts
@@ -17,9 +17,20 @@ describe('createUcValueParser', () => {
   describe('rxValue', () => {
     it('builds none without values', () => {
       const builder = new UcValueBuilder();
-      const value = builder.rxValue(rx => rx.end());
+      const charge = builder.rxValue(rx => rx.end());
 
-      expect(value).toBe(builder.none);
+      expect(charge).toBe(builder.none);
+    });
+
+    it('overrides last received charge', () => {
+      const charge = new UcValueBuilder().rxValue(rx => {
+        rx.addValue(1, 'number');
+        rx.addValue(2, 'number');
+
+        return rx.end();
+      });
+
+      expect(charge).toBe(2);
     });
   });
 });

--- a/src/charge/parse-uri-charge.spec.ts
+++ b/src/charge/parse-uri-charge.spec.ts
@@ -19,6 +19,17 @@ describe('createURIChargeParser', () => {
 
       expect(charge).toBe(URICharge.none);
     });
+    it('overrides last received charge', () => {
+      const charge = new URIChargeBuilder().rxValue(rx => {
+        rx.addValue(1, 'number');
+        rx.addValue(2, 'number');
+
+        return rx.end();
+      });
+
+      expect(charge).toBeURIChargeSingle('number');
+      expect(charge).toHaveURIChargeValue(2);
+    });
   });
 });
 

--- a/src/charge/uc-value-builder.ts
+++ b/src/charge/uc-value-builder.ts
@@ -322,8 +322,10 @@ class UcValueBuilder$MapRx<out TValue, out TRx extends UcValueBuilder<TValue>>
 
 }
 
+const OpaqueListRx = /*#__PURE__*/ OpaqueURIChargeRx.ListRx;
+
 class UcValueBuilder$ListRx<out TValue, out TRx extends UcValueBuilder<TValue>>
-  extends OpaqueValueRx<TValue, UcValue<TValue>, TRx>
+  extends OpaqueListRx<TValue, UcValue<TValue>, TRx>
   implements UcValueBuilder.ListRx<TValue, TRx> {
 
   readonly #list: UcList<TValue> = [];

--- a/src/charge/uc-value-builder.ts
+++ b/src/charge/uc-value-builder.ts
@@ -217,6 +217,10 @@ class UcValueBuilder$ValueRx<out TValue, out TRx extends UcValueBuilder<TValue>>
     }
   }
 
+  override asList(): void {
+    this.#builder = this.#builder.toList();
+  }
+
   override end(): UcValue<TValue> {
     return this.#builder.build(this);
   }
@@ -236,6 +240,7 @@ function isUcMap<TValue>(value: UcValue<TValue>): value is UcMap<TValue> {
 interface UcValue$Builder<TValue> {
   add(value: UcValue<TValue>): UcValue$Builder<TValue>;
   build(rx: URIChargeRx.ValueRx<TValue, UcValue<TValue>>): UcValue<TValue>;
+  toList(): UcValue$Builder<TValue>;
 }
 
 class UcValue$None<TValue> implements UcValue$Builder<TValue> {
@@ -246,6 +251,10 @@ class UcValue$None<TValue> implements UcValue$Builder<TValue> {
 
   build(rx: URIChargeRx.ValueRx<TValue, UcValue<TValue>>): UcValue<TValue> {
     return rx.chargeRx.none;
+  }
+
+  toList(): UcValue$Builder<TValue> {
+    return new UcValue$List([]);
   }
 
 }
@@ -268,6 +277,10 @@ class UcValue$Single<TValue> implements UcValue$Builder<TValue> {
     return this.#value;
   }
 
+  toList(): UcValue$Builder<TValue> {
+    return new UcValue$List([this.#value]);
+  }
+
 }
 
 class UcValue$List<TValue> implements UcValue$Builder<TValue> {
@@ -286,6 +299,10 @@ class UcValue$List<TValue> implements UcValue$Builder<TValue> {
 
   build(_rx: URIChargeRx.ValueRx<TValue, UcValue<TValue>>): UcValue<TValue> {
     return this.#list;
+  }
+
+  toList(): this {
+    return this;
   }
 
 }
@@ -322,10 +339,8 @@ class UcValueBuilder$MapRx<out TValue, out TRx extends UcValueBuilder<TValue>>
 
 }
 
-const OpaqueListRx = /*#__PURE__*/ OpaqueURIChargeRx.ListRx;
-
 class UcValueBuilder$ListRx<out TValue, out TRx extends UcValueBuilder<TValue>>
-  extends OpaqueListRx<TValue, UcValue<TValue>, TRx>
+  extends OpaqueValueRx<TValue, UcValue<TValue>, TRx>
   implements UcValueBuilder.ListRx<TValue, TRx> {
 
   readonly #list: UcList<TValue> = [];

--- a/src/charge/uc-value-builder.ts
+++ b/src/charge/uc-value-builder.ts
@@ -263,14 +263,16 @@ const UcValue$none: UcValue$Builder<any> = /*#__PURE__*/ new UcValue$None();
 
 class UcValue$Single<TValue> implements UcValue$Builder<TValue> {
 
-  readonly #value: UcValue<TValue>;
+  #value: UcValue<TValue>;
 
   constructor(value: UcValue<TValue>) {
     this.#value = value;
   }
 
-  add(value: UcValue<TValue>): UcValue$List<TValue> {
-    return new UcValue$List([this.#value, value]);
+  add(value: UcValue<TValue>): this {
+    this.#value = value;
+
+    return this;
   }
 
   build(_rx: URIChargeRx.ValueRx<TValue, UcValue<TValue>>): UcValue<TValue> {

--- a/src/charge/uri-charge-builder.ts
+++ b/src/charge/uri-charge-builder.ts
@@ -311,8 +311,10 @@ class URIChargeBuilder$MapRx<out TValue, out TRx extends URIChargeBuilder<TValue
 
 }
 
+const OpaqueListRx = /*#__PURE__*/ OpaqueURIChargeRx.ListRx;
+
 class URIChargeBuilder$ListRx<out TValue, out TRx extends URIChargeBuilder<TValue>>
-  extends OpaqueValueRx<URIChargeItem<TValue>, URICharge<TValue>, TRx>
+  extends OpaqueListRx<URIChargeItem<TValue>, URICharge<TValue>, TRx>
   implements URIChargeBuilder.ValueRx<TValue, TRx> {
 
   readonly #list: URICharge.Some<TValue>[] = [];

--- a/src/charge/uri-charge-builder.ts
+++ b/src/charge/uri-charge-builder.ts
@@ -254,14 +254,16 @@ const URIChargeValue$none: URIChargeValue$Builder<any> = /*#__PURE__*/ new URICh
 
 class URIChargeValue$Single<TValue> implements URIChargeValue$Builder<TValue> {
 
-  readonly #value: URICharge.Some<TValue>;
+  #value: URICharge.Some<TValue>;
 
   constructor(value: URICharge.Some<TValue>) {
     this.#value = value;
   }
 
-  add(value: URICharge.Some<TValue>): URIChargeValue$List<TValue> {
-    return new URIChargeValue$List([this.#value, value]);
+  add(value: URICharge.Some<TValue>): this {
+    this.#value = value;
+
+    return this;
   }
 
   build(_rx: URIChargeBuilder.ValueRx<TValue>): URICharge<TValue> {

--- a/src/charge/uri-charge-builder.ts
+++ b/src/charge/uri-charge-builder.ts
@@ -218,6 +218,10 @@ class URIChargeBuilder$ValueRx<out TValue, out TRx extends URIChargeBuilder<TVal
     }
   }
 
+  override asList(): void {
+    this.#builder = this.#builder.toList();
+  }
+
   override end(): URICharge<TValue> {
     return this.#builder.build(this);
   }
@@ -227,6 +231,7 @@ class URIChargeBuilder$ValueRx<out TValue, out TRx extends URIChargeBuilder<TVal
 interface URIChargeValue$Builder<out TValue> {
   add(value: URICharge.Some<TValue>): URIChargeValue$Builder<TValue>;
   build(rx: URIChargeBuilder.ValueRx<TValue>): URICharge<TValue>;
+  toList(): URIChargeValue$Builder<TValue>;
 }
 
 class URIChargeValue$None<TValue> implements URIChargeValue$Builder<TValue> {
@@ -237,6 +242,10 @@ class URIChargeValue$None<TValue> implements URIChargeValue$Builder<TValue> {
 
   build(rx: URIChargeBuilder.ValueRx<TValue>): URICharge<TValue> {
     return rx.chargeRx.none;
+  }
+
+  toList(): URIChargeValue$Builder<TValue> {
+    return new URIChargeValue$List([]);
   }
 
 }
@@ -259,6 +268,10 @@ class URIChargeValue$Single<TValue> implements URIChargeValue$Builder<TValue> {
     return this.#value;
   }
 
+  toList(): URIChargeValue$Builder<TValue> {
+    return new URIChargeValue$List([this.#value]);
+  }
+
 }
 
 class URIChargeValue$List<TValue> implements URIChargeValue$Builder<TValue> {
@@ -277,6 +290,10 @@ class URIChargeValue$List<TValue> implements URIChargeValue$Builder<TValue> {
 
   build(_rx: URIChargeBuilder.ValueRx<TValue>): URICharge<TValue> {
     return new URICharge$List(this.#list);
+  }
+
+  toList(): this {
+    return this;
   }
 
 }
@@ -311,10 +328,8 @@ class URIChargeBuilder$MapRx<out TValue, out TRx extends URIChargeBuilder<TValue
 
 }
 
-const OpaqueListRx = /*#__PURE__*/ OpaqueURIChargeRx.ListRx;
-
 class URIChargeBuilder$ListRx<out TValue, out TRx extends URIChargeBuilder<TValue>>
-  extends OpaqueListRx<URIChargeItem<TValue>, URICharge<TValue>, TRx>
+  extends OpaqueValueRx<URIChargeItem<TValue>, URICharge<TValue>, TRx>
   implements URIChargeBuilder.ValueRx<TValue, TRx> {
 
   readonly #list: URICharge.Some<TValue>[] = [];

--- a/src/charge/uri-charge-ext.spec.ts
+++ b/src/charge/uri-charge-ext.spec.ts
@@ -33,9 +33,9 @@ describe('URIChargeExt', () => {
       });
     });
     it('recognized as list item value', () => {
-      expect(parser.parse('(!test)')).toEqual({
+      expect(parser.parse(',!test')).toEqual({
         charge: [{ [test__symbol]: 'test value' }],
-        end: 7,
+        end: 6,
       });
     });
   });
@@ -49,7 +49,7 @@ describe('URIChargeExt', () => {
           directives: {
             ['!test'](_rawName: string, rawArg: string): UcValue<UcPrimitive | TestValue> {
               return target.chargeRx.rxValue(
-                rx => target.parseArgs(rawArg, new TestDirectiveRx(rx)).charge,
+                rx => target.parse(rawArg.slice(1), new TestDirectiveRx(rx)).charge,
               );
             },
           },
@@ -67,9 +67,9 @@ describe('URIChargeExt', () => {
       });
     });
     it('recognized as list item value', () => {
-      expect(parser.parse('(!test(bar)(baz))')).toEqual({
+      expect(parser.parse(',!test(bar,baz)')).toEqual({
         charge: [{ [test__symbol]: 'baz' }],
-        end: 17,
+        end: 15,
       });
     });
   });

--- a/src/charge/uri-charge-ext.ts
+++ b/src/charge/uri-charge-ext.ts
@@ -119,23 +119,6 @@ export namespace URIChargeExt {
       input: string,
       rx?: URIChargeRx.ValueRx<TValue, TCharge>,
     ): URIChargeParser.Result<TCharge>;
-
-    /**
-     * Parses the given input as if it contains arguments attached to some URI charge.
-     *
-     * Thus, the leading `(` is not recognized as list, but rather as entry value.
-     *
-     * This is used e.g. to parse {@link UcRoute.charge path fragment charge}.
-     *
-     * @param input - Input string containing encoded URI charge.
-     * @param rx - Optional URI charge value receiver. New one will be {@link URIChargeRx.rxValue created} if omitted.
-     *
-     * @returns Parse result containing charge representation.
-     */
-    parseArgs(
-      input: string,
-      rx?: URIChargeRx.ValueRx<TValue, TCharge>,
-    ): URIChargeParser.Result<TCharge>;
   }
 
   /**

--- a/src/charge/uri-charge-parser.ts
+++ b/src/charge/uri-charge-parser.ts
@@ -1,5 +1,5 @@
 import { UcPrimitive } from '../schema/uc-primitive.js';
-import { parseUcArgs, parseUcValue } from './impl/uc-value-parser.js';
+import { parseUcValue } from './impl/uc-value-parser.js';
 import { URIChargeExtParser } from './impl/uri-charge-ext-parser.js';
 import { URIChargeExt } from './uri-charge-ext.js';
 import { URIChargeRx } from './uri-charge-rx.js';
@@ -61,49 +61,6 @@ export class URIChargeParser<out TValue = UcPrimitive, out TCharge = unknown> {
 
   #parse(input: string, rx: URIChargeRx.ValueRx<TValue, TCharge>): number {
     return parseUcValue(rx, this.#ext, input);
-  }
-
-  /**
-   * Parses the given input as if it contains arguments attached to some URI charge.
-   *
-   * Thus, the leading `(` is not recognized as list, but rather as entry value.
-   *
-   * This is used e.g. to parse {@link UcRoute.charge path fragment charge}.
-   *
-   * @param input - Input string containing encoded URI charge.
-   * @param rx - Optional URI charge value receiver. New one will be {@link URIChargeRx.rxValue created} if omitted.
-   *
-   * @returns Parse result containing charge representation.
-   */
-  parseArgs(
-    input: string,
-    rx?: URIChargeRx.ValueRx<TValue, TCharge>,
-  ): URIChargeParser.Result<TCharge> {
-    if (rx) {
-      const end = this.#parseArgs(input, rx);
-
-      return { charge: rx.end(), end };
-    }
-
-    let end!: number;
-    const charge = this.chargeRx.rxValue(rx => {
-      end = this.#parseArgs(input, rx);
-
-      return rx.end();
-    });
-
-    return { charge, end };
-  }
-
-  #parseArgs(input: string, rx: URIChargeRx.ValueRx<TValue, TCharge>): number {
-    let offset = 0;
-
-    if (input.startsWith('(')) {
-      offset = 1;
-      input = input.slice(1);
-    }
-
-    return offset + parseUcArgs(rx, this.#ext, input);
   }
 
 }

--- a/src/charge/uri-charge-rx.ts
+++ b/src/charge/uri-charge-rx.ts
@@ -78,7 +78,6 @@ export namespace URIChargeRx {
   export interface Namespace {
     readonly ValueRx: ValueRx.Constructor;
     readonly MapRx: MapRx.Constructor;
-    readonly ListRx: ValueRx.Constructor;
   }
 
   /**
@@ -96,15 +95,17 @@ export namespace URIChargeRx {
   /**
    * URI charge value(s) receiver.
    *
-   * Implements a visitor pattern. Used in two flavours:
+   * Implements a visitor pattern.
+   *
+   * First, the source charge(s) added by corresponding methods. While the result charge is built when the
+   * {@link URIChargeRx.ValueRx#end end()} method called.
+   *
+   * Used in two flavours:
    *
    * - To receive single charge. In this case any added charge replaces preceding one.
    * - To receive a list. In this case any added charge represents additional list item.
    *
    * In the former case, the receiver may be {@link RxValue#asList converted} to list receiver.
-   *
-   * First, the source charge(s) added by corresponding methods. While the result charge is built when the
-   * {@link URIChargeRx.ValueRx#end end()} method called.
    *
    * @typeParam TValue - Base value type contained in URI charge. {@link UcPrimitive} by default.
    * @typeParam TCharge - URI charge representation type.
@@ -165,19 +166,13 @@ export namespace URIChargeRx {
     rxList(build: (rx: URIChargeRx.ValueRx<TValue, TCharge>) => TCharge): void;
 
     /**
-     * Builds a charge out of visited list items.
-     *
-     * This effectively converts single charge receiver to list receiver.
+     * Converts this receiver to list items receiver.
      *
      * For single charge receiver the already added charge, if any, becomes the first item of the received list.
      *
-     * For the list receiver this method just continues to build the the same list.
-     *
-     * The original receiver is discarded. Its {@link end} method will not be called.
-     *
-     * @param build - Charge builder function accepting list items receiver and building a charge with it.
+     * For the list receiver this method does nothing.
      */
-    asList(build: (rx: URIChargeRx.ValueRx<TValue, TCharge>) => TCharge): void;
+    asList(): void;
 
     /**
      * Ends receiving charges and creates the result charge.

--- a/src/charge/uri-charge-rx.ts
+++ b/src/charge/uri-charge-rx.ts
@@ -78,6 +78,7 @@ export namespace URIChargeRx {
   export interface Namespace {
     readonly ValueRx: ValueRx.Constructor;
     readonly MapRx: MapRx.Constructor;
+    readonly ListRx: ValueRx.Constructor;
   }
 
   /**
@@ -95,8 +96,12 @@ export namespace URIChargeRx {
   /**
    * URI charge value(s) receiver.
    *
-   * Implements a visitor pattern. May be used to build single value charge representation, a list item charges,
-   * directive argument(s), or map entry value.
+   * Implements a visitor pattern. Used in two flavours:
+   *
+   * - To receive single charge. In this case any added charge replaces preceding one.
+   * - To receive a list. In this case any added charge represents additional list item.
+   *
+   * In the former case, the receiver may be {@link RxValue#asList converted} to list receiver.
    *
    * First, the source charge(s) added by corresponding methods. While the result charge is built when the
    * {@link URIChargeRx.ValueRx#end end()} method called.
@@ -158,6 +163,21 @@ export namespace URIChargeRx {
      * @param build - Charge builder function accepting list items receiver and building a charge with it.
      */
     rxList(build: (rx: URIChargeRx.ValueRx<TValue, TCharge>) => TCharge): void;
+
+    /**
+     * Builds a charge out of visited list items.
+     *
+     * This effectively converts single charge receiver to list receiver.
+     *
+     * For single charge receiver the already added charge, if any, becomes the first item of the received list.
+     *
+     * For the list receiver this method just continues to build the the same list.
+     *
+     * The original receiver is discarded. Its {@link end} method will not be called.
+     *
+     * @param build - Charge builder function accepting list items receiver and building a charge with it.
+     */
+    asList(build: (rx: URIChargeRx.ValueRx<TValue, TCharge>) => TCharge): void;
 
     /**
      * Ends receiving charges and creates the result charge.

--- a/src/charge/uri-chargeable.ts
+++ b/src/charge/uri-chargeable.ts
@@ -27,93 +27,46 @@ export namespace URIChargeable {
   /**
    * The supposed placement of encoded value.
    */
-  export type Placement = Any | Entry | Tail | Arg;
-
-  /**
-   * Unknown placement of encoded value.
-   */
-  export interface Unknown {
-    /**
-     * Placement role.
-     */
-    readonly as?: string;
-
-    /**
-     * Informs the enclosing encoder that it may omit parentheses around encoded charge.
-     */
-    readonly omitParentheses?: ((this: void) => void) | undefined;
-  }
+  export type Placement = Any | Item;
 
   /**
    * The encoded value may be used placed as any part of URI charge.
    */
-  export interface Any extends Unknown {
+  export interface Any {
     readonly as?: undefined;
 
-    readonly omitParentheses?: undefined;
+    readonly omitCommaBefore?: undefined;
+
+    readonly omitCommaAfter?: undefined;
   }
 
   /**
-   * The encoded value supposed to be placed as a map entry value after opening parent.
+   * The encoded value supposed to be placed as a list item value.
    *
-   * This may affect a list. If it has two or more items, the enclosing parentheses may be omitted. So, the
+   * **Nested lists have to enclose themselves into parentheses** when placed as nested list items.
+   *
+   * Omitting commas is applicable to nested lists, so that:
    * ```
-   * foo((item1)(item2))
+   * foo((item-1.1,item-1.2),(item-2.1,item-2.2))
    * ```
    * may be encoded as
    * ```
-   * foo(item1)(item2)
+   * foo((item-1.1,item-1.2)(item-2.1,item-2.2))
    * ```
    */
-  export interface Entry extends Unknown {
-    readonly as: 'entry';
+  export interface Item {
+    readonly as: 'item';
 
     /**
-     * Informs the enclosing map encoder that it may omit parentheses around encoded entry value.
+     * Allows the enclosing list encoder to omit comma before this item if the preceding item
+     * {@link omitCommaAfter allows this too} .
      */
-    readonly omitParentheses: (this: void) => void;
-  }
-
-  /**
-   * The encoded value supposed to be placed as the last item of a list or last directive argument.
-   *
-   * This may affect a trailing item of the list containing a map. The enclosing parentheses may be omitted in this
-   * case. So, the
-   * ```
-   * (item1)(item2(foo(bar)))
-   * ```
-   * may be encoded as
-   * ```
-   * (item1)(item2)foo(bar)
-   * ```
-   */
-  export interface Tail extends Unknown {
-    readonly as: 'tail';
+    readonly omitCommaBefore: (this: void) => void;
 
     /**
-     * Informs the enclosing list encoder that it may omit parentheses around encoded item value.
+     * Allows the enclosing list encoder to omit comma after this item if the following item
+     * {@link omitCommaBefore allows this too}.
      */
-    readonly omitParentheses: (this: void) => void;
-  }
-
-  /**
-   * The encoded value supposed to be placed as an argument value after opening parent.
-   *
-   * This may affect a list. If it has two or more items, the enclosing parentheses may be omitted. So, the
-   * ```
-   * !foo((arg1)(arg2)arg3(value)suffix)
-   * ```
-   * may be encoded as
-   * ```
-   !foo(arg1)(arg2)arg3(value)suffix
-   * ```
-   */
-  export interface Arg extends Unknown {
-    readonly as: 'arg';
-
-    /**
-     * Informs the enclosing directive encoder that it may omit parentheses around encoded argument(s).
-     */
-    readonly omitParentheses: (this: void) => void;
+    readonly omitCommaAfter: (this: void) => void;
   }
 }

--- a/src/compiler/serialization/ucs-defs.ts
+++ b/src/compiler/serialization/ucs-defs.ts
@@ -4,5 +4,10 @@ import { UcsFunction } from './ucs-function.js';
 
 export interface UcsDefs {
   readonly from: string;
-  serialize(serializer: UcsFunction, schema: UcSchema, value: string): UccCode.Source | undefined;
+  serialize(
+    serializer: UcsFunction,
+    schema: UcSchema,
+    value: string,
+    asItem: string,
+  ): UccCode.Source | undefined;
 }

--- a/src/compiler/serialization/ucs-function.ts
+++ b/src/compiler/serialization/ucs-function.ts
@@ -46,8 +46,8 @@ export class UcsFunction<out T = unknown, out TSchema extends UcSchema<T> = UcSc
     return this.#lib.aliases;
   }
 
-  serialize(schema: UcSchema, value: string): UccCode.Source {
-    const serializer = this.lib.definitionsFor(schema)?.serialize(this, schema, value);
+  serialize(schema: UcSchema, value: string, asItem = '0'): UccCode.Source {
+    const serializer = this.lib.definitionsFor(schema)?.serialize(this, schema, value, asItem);
 
     if (serializer == null) {
       throw new UnsupportedUcSchemaError(
@@ -61,8 +61,10 @@ export class UcsFunction<out T = unknown, out TSchema extends UcSchema<T> = UcSc
 
   toCode(): UccCode.Source {
     return code => code
-        .write(`async function ${this.name}(${this.args.writer}, ${this.args.value}) {`)
-        .indent(this.serialize(this.schema, this.args.value))
+        .write(
+          `async function ${this.name}(${this.args.writer}, ${this.args.value}, ${this.args.asItem}) {`,
+        )
+        .indent(this.serialize(this.schema, this.args.value, this.args.asItem))
         .write('}');
   }
 
@@ -101,5 +103,6 @@ export namespace UcsFunction {
   export interface Args {
     readonly writer: string;
     readonly value: string;
+    readonly asItem: string;
   }
 }

--- a/src/compiler/serialization/ucs-lib.ts
+++ b/src/compiler/serialization/ucs-lib.ts
@@ -53,6 +53,7 @@ export class UcsLib<TSchemae extends UcsLib.Schemae = UcsLib.Schemae> {
     this.#serializerArgs = {
       writer: aliases.aliasFor('writer'),
       value: aliases.aliasFor('value'),
+      asItem: aliases.aliasFor('asItem'),
     };
 
     for (const [externalName, schema] of Object.entries(this.#schemae)) {

--- a/src/ext/non-finite.uc-ext.spec.ts
+++ b/src/ext/non-finite.uc-ext.spec.ts
@@ -10,7 +10,7 @@ describe('NonFiniteUcExt', () => {
       expect(parseUcValue('foo(!Infinity)').charge).toEqual({ foo: Infinity });
     });
     it('recognized as list item value', () => {
-      expect(parseUcValue('(!Infinity)').charge).toEqual([Infinity]);
+      expect(parseUcValue(',!Infinity').charge).toEqual([Infinity]);
     });
 
     describe('-Infinity', () => {
@@ -21,7 +21,7 @@ describe('NonFiniteUcExt', () => {
         expect(parseUcValue('foo(!-Infinity)').charge).toEqual({ foo: -Infinity });
       });
       it('recognized as list item value', () => {
-        expect(parseUcValue('(!-Infinity)').charge).toEqual([-Infinity]);
+        expect(parseUcValue(',!-Infinity').charge).toEqual([-Infinity]);
       });
     });
 
@@ -33,7 +33,7 @@ describe('NonFiniteUcExt', () => {
         expect(parseUcValue('foo(!NaN)').charge).toEqual({ foo: NaN });
       });
       it('recognized as list item value', () => {
-        expect(parseUcValue('(!NaN)').charge).toEqual([NaN]);
+        expect(parseUcValue(',!NaN').charge).toEqual([NaN]);
       });
     });
   });

--- a/src/impl/ascii-char-set.ts
+++ b/src/impl/ascii-char-set.ts
@@ -21,6 +21,14 @@ export class ASCIICharSet {
     this.#mask = mask;
   }
 
+  has(charCode: number): number | boolean {
+    return (
+      charCode <= this.#max
+      && charCode >= this.#min
+      && this.#mask & (1 << (charCode - this.#min))
+    );
+  }
+
   prefixes(input: string): number | boolean {
     const firstCode = input.charCodeAt(0);
 

--- a/src/impl/encode-ucs-string.ts
+++ b/src/impl/encode-ucs-string.ts
@@ -1,3 +1,5 @@
+import { prefixUcKey } from './uc-string-escapes.js';
+
 /**
  * URL-encode special symbols for the use within `application/uri-charge`.
  */
@@ -8,8 +10,22 @@ export function encodeUcsString(value: string): string {
   );
 }
 
+/**
+ * URL-encode and escape special symbols for the use as entry key within `application/uri-charge`.
+ */
+export function encodeUcsKey(key: string): string {
+  return prefixUcKey(encodeUcsString(key));
+}
+
+/**
+ * Encode all ASCII special chars except `\r`, `\n`, and `\t`.
+ *
+ * Encode symbols with special meaning as well.
+ *
+ * Do not encode anything else. It is not needed within `application/uri-charge` content.
+ */
 // eslint-disable-next-line no-control-regex
 const UCS_STRING_ENCODE_PATTERN = /[\x00-\x08\x0b\x0c\x0e-\x1f%(),]/g;
 const UCS_STRING_ENCODE_LIST = /*#__PURE__*/ new Array(','.charCodeAt(0) + 1)
-  .fill(' ')
+  .fill(null)
   .map((_char, index) => '%' + index.toString(16).padStart(2, '0').toUpperCase());

--- a/src/impl/uc-string-escapes.ts
+++ b/src/impl/uc-string-escapes.ts
@@ -11,8 +11,10 @@ const UC_ESCAPED = /*#__PURE__*/ new ASCIICharSet("!$'-0123456789");
 const UC_KEY_ESCAPED = /*#__PURE__*/ new ASCIICharSet("!$'");
 
 export function escapeUcKey(encoded: string, subsequent: boolean): string {
-  const escaped = escapeUcSpecials(encoded);
+  return prefixUcKey(escapeUcSpecials(encoded), subsequent);
+}
 
+export function prefixUcKey(escaped: string, subsequent = false): string {
   return (!subsequent && escaped.length > 63) || UC_KEY_ESCAPED.prefixes(escaped)
     ? `$${escaped}`
     : escaped;

--- a/src/readme.spec.ts
+++ b/src/readme.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from '@jest/globals';
+import { chargeURI } from './charge/charge-uri.js';
+import { churi } from './charge/churi.tag.js';
+import { UcDirective } from './schema/uc-directive.js';
+import { UcEntity } from './schema/uc-entity.js';
+
+const DOC_EXAMPLE =
+  'https://example.com/api(!v(3.0))/user;id=0n302875106592253'
+  + '/article;slug=hello-world/comments?date=since(!date(1970-01-01))till(!now)&range=from(10)to(20)';
+
+describe('README.md', () => {
+  describe('churi tag example', () => {
+    it('is correct', () => {
+      expect(churi`
+        https://example.com
+          /api(${new UcDirective('!v', '(3.0)')})
+          /user;id=${302875106592253n}
+          /article;slug=${'hello-world'}
+          /comments
+            ?date=${{
+              since: new UcDirective('!date', '(1970-01-01)'),
+              till: new UcEntity('!now'),
+            }}
+            &range=${{
+              from: 10,
+              to: 20,
+            }}
+      `).toBe(DOC_EXAMPLE);
+    });
+  });
+
+  describe('chargeURI example', () => {
+    it('is correct', () => {
+      expect(
+        'https://example.com'
+          + `/api(${chargeURI(new UcDirective('!v', '(3.0)'))})`
+          + `/user;id=${chargeURI(302875106592253n)}`
+          + `/article;slug=${chargeURI('hello-world')}`
+          + '/comments'
+          + `?date=${chargeURI({
+            since: new UcDirective('!date', '(1970-01-01)'),
+            till: new UcEntity('!now'),
+          })}`
+          + `&range=${chargeURI({
+            from: 10,
+            to: 20,
+          })}`,
+      ).toBe(DOC_EXAMPLE);
+    });
+  });
+});

--- a/src/serializer/ucs-constants.ts
+++ b/src/serializer/ucs-constants.ts
@@ -1,8 +1,8 @@
 export const UCS_APOSTROPHE = /*#__PURE__*/ new Uint8Array([0x27]); // `'`
 export const UCS_OPENING_PARENTHESIS = /*#__PURE__*/ new Uint8Array([0x28]); // `(`
 export const UCS_CLOSING_PARENTHESIS = /*#__PURE__*/ new Uint8Array([0x29]); // `)`
-export const UCS_LIST_ITEM_SEPARATOR = /*#__PURE__*/ new Uint8Array([0x29, 0x28]); // `)(`
-export const UCS_EMPTY_LIST = /*#__PURE__*/ new Uint8Array([0x21, 0x21]); // `!!`
+export const UCS_COMMA = /*#__PURE__*/ new Uint8Array([0x2c]); // `,`
+export const UCS_EMPTY_LIST = /*#__PURE__*/ new Uint8Array([0x28, 0x29]); // `()`
 export const UCS_EMPTY_MAP = /*#__PURE__*/ new Uint8Array([0x24]); // `$`
 export const UCS_EMPTY_ENTRY_PREFIX = /*#__PURE__*/ new Uint8Array([0x24, 0x28]); // `$(`
 export const UCS_NULL = /*#__PURE__*/ new Uint8Array([0x2d, 0x2d]); // `--`

--- a/src/uc-route.spec.ts
+++ b/src/uc-route.spec.ts
@@ -44,6 +44,18 @@ describe('UcRoute', () => {
       expect(new UcRoute('path/').name).toBe('path');
       expect(new UcRoute('/path/').name).toBe('path');
     });
+    it('omits dollar prefix', () => {
+      expect(new UcRoute('/$some').name).toBe('some');
+      expect(new UcRoute('/$some,other').name).toBe('some');
+      expect(new UcRoute('/$some(foo)').name).toBe('some');
+    });
+    it('omits quote', () => {
+      expect(new UcRoute("/'some").name).toBe('some');
+      expect(new UcRoute("/'some,other").name).toBe('some');
+    });
+    it('does not omit quote of entry key', () => {
+      expect(new UcRoute("/'some(foo)").name).toBe("'some");
+    });
     it('omits charge', () => {
       expect(new UcRoute('name(foo)').name).toBe('name');
       expect(new UcRoute('name(foo);p=bar').name).toBe('name');

--- a/src/uc-route.spec.ts
+++ b/src/uc-route.spec.ts
@@ -120,17 +120,20 @@ describe('UcRoute', () => {
   });
 
   describe('charge', () => {
-    it('is none without charge', () => {
-      expect(new UcRoute('/path').charge).toBeURIChargeNone();
+    it('is string value without charge', () => {
+      expect(new UcRoute('/path').charge).toHaveURIChargeValue('path');
     });
     it('recognizes single charge', () => {
-      expect(new UcRoute('/path(foo)').charge).toHaveURIChargeValue('foo');
+      expect(new UcRoute('/path(foo)').charge).toHaveURIChargeItems({ path: 'foo' });
     });
     it('recognizes list charge', () => {
-      expect(new UcRoute('/path(foo)(bar)').charge).toHaveURIChargeItems('foo', 'bar');
+      expect(new UcRoute('/path,foo,bar)').charge).toHaveURIChargeItems('path', 'foo', 'bar');
     });
     it('recognizes map charge', () => {
-      expect(new UcRoute('/path(foo)bar(baz)').charge).toHaveURIChargeItems('foo', { bar: 'baz' });
+      expect(new UcRoute('/path(foo)bar(baz)').charge).toHaveURIChargeItems({
+        path: 'foo',
+        bar: 'baz',
+      });
     });
   });
 

--- a/src/uc-route.ts
+++ b/src/uc-route.ts
@@ -79,15 +79,13 @@ export class UcRoute<out TValue = UcPrimitive, out TCharge = URICharge<TValue>> 
     let name: string;
 
     if (nameEnd < 0) {
-      name = charge;
+      name = charge.startsWith('$') || charge.startsWith("'") ? charge.slice(1) : charge;
+    } else if (charge.startsWith('$')) {
+      name = charge.slice(1, nameEnd);
     } else {
       const nameDelimiter = charge[nameEnd];
 
-      if (nameDelimiter === '(') {
-        name = charge.slice(charge.startsWith('$') ? 1 : 0, nameEnd);
-      } else {
-        name = charge.slice(charge.startsWith("'") || charge.startsWith('$') ? 1 : 0, nameEnd);
-      }
+      name = charge.slice(nameDelimiter !== '(' && charge.startsWith("'") ? 1 : 0, nameEnd);
     }
 
     return {
@@ -99,10 +97,6 @@ export class UcRoute<out TValue = UcPrimitive, out TCharge = URICharge<TValue>> 
 
   #parseCharge(): TCharge {
     const { charge } = this.#getParts();
-
-    if (charge == null) {
-      return this.chargeParser.chargeRx.none;
-    }
 
     return this.chargeParser.parse(charge).charge;
   }
@@ -238,7 +232,7 @@ const CHURI_NAME_DELIMITER_PATTERN = /[,()]/;
 
 interface UcRoute$Parts {
   readonly name: string;
-  readonly charge: string | undefined;
+  readonly charge: string;
   readonly matrix: string | undefined;
 }
 

--- a/src/uc-route.ts
+++ b/src/uc-route.ts
@@ -65,25 +65,29 @@ export class UcRoute<out TValue = UcPrimitive, out TCharge = URICharge<TValue>> 
     }
 
     const matrixStart = rawFragment.indexOf(';');
-    let nameAndCharge: string;
+    let charge: string;
     let matrix: string | undefined;
 
     if (matrixStart < 0) {
-      nameAndCharge = rawFragment;
+      charge = rawFragment;
     } else {
-      nameAndCharge = rawFragment.slice(0, matrixStart);
+      charge = rawFragment.slice(0, matrixStart);
       matrix = rawFragment.slice(matrixStart + 1);
     }
 
-    const chargeStart = nameAndCharge.indexOf('(');
+    const nameEnd = charge.search(CHURI_NAME_DELIMITER_PATTERN);
     let name: string;
-    let charge: string | undefined;
 
-    if (chargeStart < 0) {
-      name = nameAndCharge;
+    if (nameEnd < 0) {
+      name = charge;
     } else {
-      name = nameAndCharge.slice(0, chargeStart);
-      charge = nameAndCharge.slice(chargeStart);
+      const nameDelimiter = charge[nameEnd];
+
+      if (nameDelimiter === '(') {
+        name = charge.slice(charge.startsWith('$') ? 1 : 0, nameEnd);
+      } else {
+        name = charge.slice(charge.startsWith("'") || charge.startsWith('$') ? 1 : 0, nameEnd);
+      }
     }
 
     return {
@@ -100,7 +104,7 @@ export class UcRoute<out TValue = UcPrimitive, out TCharge = URICharge<TValue>> 
       return this.chargeParser.chargeRx.none;
     }
 
-    return this.chargeParser.parseArgs(charge).charge;
+    return this.chargeParser.parse(charge).charge;
   }
 
   /**
@@ -229,6 +233,8 @@ export class UcRoute<out TValue = UcPrimitive, out TCharge = URICharge<TValue>> 
   }
 
 }
+
+const CHURI_NAME_DELIMITER_PATTERN = /[,()]/;
 
 interface UcRoute$Parts {
   readonly name: string;

--- a/src/uc-search-params.spec.ts
+++ b/src/uc-search-params.spec.ts
@@ -257,7 +257,7 @@ describe('UcSearchParams', () => {
 
   describe('charge', () => {
     it('obtains parameter charges', () => {
-      const params = new UcSearchParams('?foo=bar(test)&foo=1&baz=(21)(22)&test');
+      const params = new UcSearchParams('?foo=bar(test)&foo=1&baz=21,22&test');
 
       expect(params.chargeOf('foo')).toHaveURIChargeItems({ bar: 'test' }, 1);
       expect(params.chargeOf('baz')).toHaveURIChargeItems(21, 22);


### PR DESCRIPTION
- Value-to-list receiver conversion
- Allow balanced parenthesis in quoted strings
- Comma-separated list parser
- `chargeURI`: Proper charging
- Handle commas in `churi` template string
- Charge `undefined` as `null`
- Ensure empty string items charged properly
- Ensure empty items parsed correctly
- Proper route name extraction
- Ensure nested lists charge
- Simplify value rx implementations
- Serialize comma-separated lists
- Update examples
- Document comma-separated lists
