### PR TITLE
Emit dependencies before declarations

### DIFF
--- a/build/emit-exports.js
+++ b/build/emit-exports.js
@@ -16,8 +16,6 @@ class DefaultUcdLib extends UcdLib {
 
 }
 
-const lib = new DefaultUcdLib();
-
 await Promise.all([
   emitDefaultEntities(),
   emitUcValueDeserializer(),
@@ -29,6 +27,8 @@ await Promise.all([
 ]);
 
 async function emitDefaultEntities() {
+  const lib = new DefaultUcdLib();
+
   await fs.writeFile(
     path.join(distDir, 'churi.default-entities.js'),
     new UccCode()
@@ -47,6 +47,8 @@ async function emitDefaultEntities() {
 }
 
 async function emitUcValueDeserializer() {
+  const lib = new DefaultUcdLib();
+
   await fs.writeFile(
     path.join(distDir, 'churi.uc-value.deserializer.js'),
     lib.compileModule('sync').print(),

--- a/src/compiler/codegen/ucc-declarations.ts
+++ b/src/compiler/codegen/ucc-declarations.ts
@@ -1,12 +1,14 @@
 import { safeJsId } from '../impl/safe-js-id.js';
 import { UccCode, UccFragment, UccSource } from './ucc-code.js';
 import { UccNamespace } from './ucc-namespace.js';
+import { UccPrinter } from './ucc-printer.js';
 
 export class UccDeclarations implements UccFragment {
 
   readonly #ns: UccNamespace;
-  readonly #snippets = new Map<string, string>();
-  readonly #code = new UccCode();
+  readonly #stack = new UccDeclStack();
+  readonly #byKey = new Map<string, UccDeclSnippet>();
+  readonly #all: UccDeclSnippet[] = [];
 
   constructor(ns: UccNamespace) {
     this.#ns = ns;
@@ -56,10 +58,6 @@ export class UccDeclarations implements UccFragment {
     );
   }
 
-  toCode(): UccSource {
-    return code => code.write(this.#code);
-  }
-
   #declare(
     id: string,
     snippet: (name: string) => UccSource,
@@ -70,22 +68,138 @@ export class UccDeclarations implements UccFragment {
     if (key != null) {
       snippetKey = key === id ? `id:${id}` : `key:${key}`;
 
-      const knownName = this.#snippets.get(snippetKey);
+      const knownSnippet = this.#byKey.get(snippetKey);
 
-      if (knownName) {
-        return knownName;
+      if (knownSnippet) {
+        this.#stack.addDep(knownSnippet);
+
+        return knownSnippet.name;
       }
     }
 
     const name = this.#ns.name(id);
-
-    this.#code.write(snippet(name));
+    const newSnippet = new UccDeclSnippet(name, snippet);
 
     if (snippetKey) {
-      this.#snippets.set(snippetKey, name);
+      this.#byKey.set(snippetKey, newSnippet);
     }
+    this.#all.push(newSnippet);
+    this.#stack.addDep(newSnippet);
 
     return name;
+  }
+
+  toCode(): UccSource {
+    return {
+      prePrint: () => {
+        const records = this.#prePrintAll();
+
+        return {
+          printTo: lines => this.#printAll(lines, records),
+        };
+      },
+    };
+  }
+
+  #prePrintAll(): Map<UccDeclSnippet, string | UccPrinter.Record> {
+    const records = new Map<UccDeclSnippet, string | UccPrinter.Record>();
+
+    for (const snippet of this.#all) {
+      this.#prePrintSnippet(snippet, records);
+    }
+
+    return records;
+  }
+
+  #prePrintSnippet(
+    snippet: UccDeclSnippet,
+    records: Map<UccDeclSnippet, string | UccPrinter.Record>,
+  ): void {
+    if (!records.has(snippet)) {
+      const prev = this.#stack.start(snippet);
+
+      try {
+        records.set(snippet, '/* Printing... */'); // Prevent recurrent duplicates.
+        records.set(snippet, snippet.prePrint());
+      } finally {
+        this.#stack.end(prev);
+      }
+    }
+  }
+
+  #printAll(
+    lines: UccPrinter.Lines,
+    records: Map<UccDeclSnippet, string | UccPrinter.Record>,
+  ): void {
+    const printed = new Set<UccDeclSnippet>();
+
+    for (const [snippet, record] of records) {
+      this.#printSnippet(snippet, record, records, printed, lines);
+    }
+  }
+
+  #printSnippet(
+    snippet: UccDeclSnippet,
+    record: string | UccPrinter.Record,
+    records: Map<UccDeclSnippet, string | UccPrinter.Record>,
+    printed: Set<UccDeclSnippet>,
+    lines: UccPrinter.Lines,
+  ): void {
+    if (!printed.has(snippet)) {
+      // Prevent infinite recursion.
+      printed.add(snippet);
+
+      // First, print all snipped dependencies.
+      for (const dep of snippet.deps) {
+        this.#printSnippet(dep, records.get(dep)!, records, printed, lines);
+      }
+
+      // Then, print the snippet itself.
+      lines.print(record);
+    }
+  }
+
+}
+
+class UccDeclStack {
+
+  #top: UccDeclSnippet | null = null;
+
+  start(snippet: UccDeclSnippet): UccDeclSnippet | null {
+    const top = this.#top;
+
+    this.#top = snippet;
+
+    return top;
+  }
+
+  addDep(dependency: UccDeclSnippet): void {
+    this.#top?.deps.add(dependency);
+  }
+
+  end(top: UccDeclSnippet | null): void {
+    this.#top = top;
+  }
+
+}
+
+class UccDeclSnippet {
+
+  readonly #name: string;
+  readonly #snippet: (name: string) => UccSource;
+  readonly deps = new Set<UccDeclSnippet>();
+
+  constructor(name: string, snippet: (name: string) => UccSource) {
+    this.#name = name;
+    this.#snippet = snippet;
+  }
+
+  get name(): string {
+    return this.#name;
+  }
+
+  prePrint(): string | UccPrinter.Record {
+    return new UccCode().write(this.#snippet(this.#name)).prePrint();
   }
 
 }

--- a/src/compiler/deserialization/list.ucd-def.ts
+++ b/src/compiler/deserialization/list.ucd-def.ts
@@ -31,6 +31,7 @@ export class ListUcdDef<
     return new this(lib, schema);
   }
 
+  #typeName?: string;
   #itemTemplate?: UcrxTemplate;
   #allocation?: ListUcdDef.Allocation;
 
@@ -46,12 +47,13 @@ export class ListUcdDef<
     return this.#isMatrix ? this.lib.voidUcrx : this.#getItemTemplate();
   }
 
-  override get permitsSingle(): boolean {
-    return false;
+  override get typeName(): string {
+    return (this.#typeName ??=
+      'List' + ucUcSchemaVariant(this.schema) + 'Of' + this.#getItemTemplate().typeName);
   }
 
-  protected override preferredClassName(): string {
-    return 'List' + ucUcSchemaVariant(this.schema) + 'Of' + this.#getItemTemplate().className;
+  override get permitsSingle(): boolean {
+    return false;
   }
 
   protected override discoverTypes(): Set<string> {

--- a/src/compiler/deserialization/unknown.ucd-def.ts
+++ b/src/compiler/deserialization/unknown.ucd-def.ts
@@ -32,8 +32,8 @@ export class UnknownUcdDef extends CustomUcrxTemplate {
     });
   }
 
-  protected override preferredClassName(): string {
-    return this.schema.nullable ? 'AnyUcrx' : 'NonNullUcrx';
+  override get typeName(): string {
+    return this.schema.nullable ? 'Any' : 'NonNull';
   }
 
   protected override discoverTypes(): Set<string> {

--- a/src/compiler/impl/custom-base.ucrx-template.ts
+++ b/src/compiler/impl/custom-base.ucrx-template.ts
@@ -22,6 +22,10 @@ export class CustomBaseUcrxTemplate extends BaseUcrxTemplate {
     return this.#base;
   }
 
+  override get typeName(): string {
+    return `Base`;
+  }
+
   override get className(): string {
     return (this.#className ??= this.#declareClass());
   }
@@ -37,9 +41,13 @@ export class CustomBaseUcrxTemplate extends BaseUcrxTemplate {
   }
 
   #declareClass(): string {
-    return this.lib.declarations.declareClass('BaseUcrx', name => this.#declareBody(name), {
-      baseClass: this.base.className,
-    });
+    return this.lib.declarations.declareClass(
+      `${this.typeName}Ucrx`,
+      name => this.#declareBody(name),
+      {
+        baseClass: this.base.className,
+      },
+    );
   }
 
   #declareBody(_className: string): UccSource {

--- a/src/compiler/impl/custom-opaque.ucrx-template.ts
+++ b/src/compiler/impl/custom-opaque.ucrx-template.ts
@@ -11,6 +11,10 @@ export class CustomOpaqueUcrxTemplate extends BaseUcrxTemplate {
     super({ lib, args: [] });
   }
 
+  override get typeName(): string {
+    return `Opaque`;
+  }
+
   override get className(): string {
     return (this.#className ??= this.#declareClass());
   }
@@ -22,9 +26,13 @@ export class CustomOpaqueUcrxTemplate extends BaseUcrxTemplate {
   }
 
   #declareClass(): string {
-    return this.lib.declarations.declareClass('OpaqueUcrx', name => this.#declareBody(name), {
-      baseClass: this.base.className,
-    });
+    return this.lib.declarations.declareClass(
+      `${this.typeName}Ucrx`,
+      name => this.#declareBody(name),
+      {
+        baseClass: this.base.className,
+      },
+    );
   }
 
   #declareBody(_className: string): UccSource {

--- a/src/compiler/impl/void.ucrx-template.ts
+++ b/src/compiler/impl/void.ucrx-template.ts
@@ -14,12 +14,16 @@ export class VoidUcrxTemplate extends BaseUcrxTemplate {
     return;
   }
 
+  override get typeName(): string {
+    return 'Void';
+  }
+
   override get className(): string {
     return (this.#className ??= this.#importClass());
   }
 
   #importClass(): string {
-    return this.lib.import(CHURI_MODULE, 'VoidUcrx');
+    return this.lib.import(CHURI_MODULE, `${this.typeName}Ucrx`);
   }
 
 }

--- a/src/compiler/rx/base.ucrx-template.ts
+++ b/src/compiler/rx/base.ucrx-template.ts
@@ -36,6 +36,8 @@ export abstract class BaseUcrxTemplate {
     return this.lib.voidUcrx;
   }
 
+  abstract get typeName(): string;
+
   abstract get className(): string;
 
   get args(): UcrxArgs {

--- a/src/compiler/rx/custom.ucrx-template.ts
+++ b/src/compiler/rx/custom.ucrx-template.ts
@@ -33,6 +33,10 @@ export class CustomUcrxTemplate<
     return this.#schema;
   }
 
+  override get typeName(): string {
+    return ucSchemaTypeSymbol(this.schema);
+  }
+
   override get className(): string {
     return (this.#className ??= this.#declareClass());
   }
@@ -41,14 +45,10 @@ export class CustomUcrxTemplate<
     const { base } = this;
 
     return this.lib.declarations.declareClass(
-      this.preferredClassName(),
+      `${this.typeName}Ucrx`,
       name => this.#declareBody(name),
       { baseClass: base.className },
     );
-  }
-
-  protected preferredClassName(): string {
-    return ucSchemaTypeSymbol(this.schema) + 'Ucrx';
   }
 
   #declareBody(className: string): UccSource {

--- a/src/compiler/rx/custom.ucrx-template.ts
+++ b/src/compiler/rx/custom.ucrx-template.ts
@@ -48,7 +48,7 @@ export class CustomUcrxTemplate<
   }
 
   protected preferredClassName(): string {
-    return ucSchemaTypeSymbol(this.schema);
+    return ucSchemaTypeSymbol(this.schema) + 'Ucrx';
   }
 
   #declareBody(className: string): UccSource {


### PR DESCRIPTION
- Add `Ucrx` prefix to class name
- Add type name to Ucrx template
- Print deps _before_ declarations
- Omit redundant imports
